### PR TITLE
Configurable header attributes.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -60,11 +60,6 @@ class Builder
     protected $tableAttributes = ['class' => 'table', 'id' => 'dataTableBuilder'];
 
     /**
-     * @var array
-     */
-    protected $allowedHeaderAttributes = ['class', 'id', 'width', 'style', 'data-class', 'data-hide'];
-
-    /**
      * @var string
      */
     protected $template = '';
@@ -568,10 +563,9 @@ class Builder
      * @param bool $drawFooter
      * @return string
      */
-    public function table(array $attributes = [], $drawFooter = false, array $headerAttributes = [])
+    public function table(array $attributes = [], $drawFooter = false)
     {
         $this->tableAttributes = array_merge($this->tableAttributes, $attributes);
-        $this->allowedHeaderAttributes = array_merge($this->allowedHeaderAttributes, $headerAttributes);
 
         $th       = $this->compileTableHeaders();
         $htmlAttr = $this->html->attributes($this->tableAttributes);
@@ -596,9 +590,10 @@ class Builder
     {
         $th = [];
         foreach ($this->collection->toArray() as $row) {
-            $thAttr = $this->html->attributes(
-                array_only($row, $this->allowedHeaderAttributes)
-            );
+            $thAttr = $this->html->attributes(array_merge(
+                array_only($row, ['class', 'id', 'width', 'style', 'data-class', 'data-hide']),
+                $row['attributes']
+            ));
             $th[]   = '<th ' . $thAttr . '>' . $row['title'] . '</th>';
         }
 

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -60,6 +60,11 @@ class Builder
     protected $tableAttributes = ['class' => 'table', 'id' => 'dataTableBuilder'];
 
     /**
+     * @var array
+     */
+    protected $allowedHeaderAttributes = ['class', 'id', 'width', 'style', 'data-class', 'data-hide'];
+
+    /**
      * @var string
      */
     protected $template = '';
@@ -563,9 +568,10 @@ class Builder
      * @param bool $drawFooter
      * @return string
      */
-    public function table(array $attributes = [], $drawFooter = false)
+    public function table(array $attributes = [], $drawFooter = false, array $headerAttributes = [])
     {
         $this->tableAttributes = array_merge($this->tableAttributes, $attributes);
+        $this->allowedHeaderAttributes = array_merge($this->allowedHeaderAttributes, $headerAttributes);
 
         $th       = $this->compileTableHeaders();
         $htmlAttr = $this->html->attributes($this->tableAttributes);
@@ -591,7 +597,7 @@ class Builder
         $th = [];
         foreach ($this->collection->toArray() as $row) {
             $thAttr = $this->html->attributes(
-                array_only($row, ['class', 'id', 'width', 'style', 'data-class', 'data-hide'])
+                array_only($row, $this->allowedHeaderAttributes)
             );
             $th[]   = '<th ' . $thAttr . '>' . $row['title'] . '</th>';
         }

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -23,6 +23,7 @@ class Column extends Fluent
         $attributes['exportable'] = isset($attributes['exportable']) ? $attributes['exportable'] : true;
         $attributes['printable']  = isset($attributes['printable']) ? $attributes['printable'] : true;
         $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '';
+        $attributes['attributes'] = isset($attributes['attributes']) ? $attributes['attributes'] : [];
 
         // Allow methods override attribute value
         foreach ($attributes as $attribute => $value) {


### PR DESCRIPTION
this PR allow user to add custom attributes on the table header.
i think some user might be need to add custom html attributes on the header.

in my case, i need to display a tooltip when hovering on the header, so i need to add "data-toggle" attributes on the header.

it will looks like this on the view

```php
{!! $dataTable->table([], true, ['data-toggle', 'data-container', 'data-title']) !!}
```

on the datatables service class, users are able to define custom attributes on each columns.

```php
namespace App\DataTables;

use App\Models\Category;
use Yajra\Datatables\Services\DataTable;

class CategoryDataTable extends DataTable
{

    // ...

    /**
     * Get columns.
     *
     * @return array
     */
    protected function getColumns()
    {
        return [
            'name' => [
                'data-toggle' => 'tooltip',
                'data-title' => 'Tooltip Description',
                'data-container' => 'body'
            ]
        ];
    }

}
```

what do you think?