### PR TITLE
Adding Multiple Table Rendering Feature

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -129,15 +129,46 @@ class Builder
     }
 
     /**
+     * Determine if the datatable has a custom id.
+     *  
+     * @return boolean
+     */
+    private function hasCustomTableId()
+    {
+        return $this->tableAttributes['id'] != 'dataTableBuilder';
+    }
+
+    /**
+     * Prepare ajax attributes.
+     */
+    private function prepareAjaxAttributes()
+    {
+        $queryString = '';
+        if ($this->hasCustomTableId()) {
+            $queryString = '?'.http_build_query([
+                'tableId' => $this->tableAttributes['id'],
+            ]);
+        }
+
+        if (is_array($this->ajax)) {
+            $this->ajax['url'] = $this->ajax['url'].$queryString;
+        } else {
+            $this->ajax = $this->ajax.$queryString;
+        }
+    }
+
+    /**
      * Get generated raw scripts.
      *
      * @return string
      */
     public function generateScripts()
     {
+        $this->prepareAjaxAttributes();
+
         $args = array_merge(
             $this->attributes, [
-                'ajax'    => "{$this->ajax}?tableId={$this->tableAttributes['id']}",
+                'ajax'    => $this->ajax,
                 'columns' => $this->collection->toArray(),
             ]
         );

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -576,7 +576,7 @@ class Builder
             return '';
         }
 
-        $url = is_array($ajax) ? $this->ajax['url'] : $this->ajax;
+        $url = is_array($this->ajax) ? $this->ajax['url'] : $this->ajax;
 
         $hasQueryString = str_contains($url, ['?']);
         $separator = $hasQueryString ? '&' : '?';

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -572,9 +572,18 @@ class Builder
 
     public function getQueryString()
     {
-        return $this->hasCustomTableId() ? '?'.http_build_query([
+        if (!$this->hasCustomTableId()) {
+            return '';
+        }
+
+        $url = is_array($ajax) ? $this->ajax['url'] : $this->ajax;
+
+        $hasQueryString = str_contains($url, ['?']);
+        $separator = $hasQueryString ? '&' : '?';
+
+        return $separator.http_build_query([
             'tableId' => $this->tableAttributes['id'],
-        ]) : '';
+        ]);
     }
 
     /**

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -161,7 +161,7 @@ class Builder
     }
 
     /**
-     * Translates literal jQuery functions to key value pairs. (Recursively)
+     * Translates literal javascript functions to key value pairs. (Recursively)
      * 
      * @param  array &$parameters
      * @param  array $values
@@ -169,14 +169,13 @@ class Builder
      * 
      * @return array
      */
-    public function parseJQueryFunctions(&$parameters, $values = [], $replacements = [])
+    public function parseJavascriptFunctions(&$parameters, $values = [], $replacements = [])
     {
         foreach($parameters as $key => &$value) {
             if (is_array($value)) {
-                list($values, $replacements) = $this->parseJQueryFunctions($value, $values, $replacements);
+                list($values, $replacements) = $this->parseJavascriptFunctions($value, $values, $replacements);
             } else {
-                if (strpos($value, '$.') === 0)
-                {
+                if (str_contains($value, ['$.', 'function'])) {
                     // Store function string.
                     $values[] = $value;
                     // Replace function string in $foo with a 'unique' special key.
@@ -200,7 +199,7 @@ class Builder
     {
         $parameters = (new Parameters($attributes))->toArray();
 
-        list($values, $replacements) = $this->parseJQueryFunctions($parameters);
+        list($values, $replacements) = $this->parseJavascriptFunctions($parameters);
 
         list($ajaxDataFunction, $parameters) = $this->encodeAjaxDataFunction($parameters);
         list($columnFunctions, $parameters) = $this->encodeColumnFunctions($parameters);

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -137,7 +137,7 @@ class Builder
     {
         $args = array_merge(
             $this->attributes, [
-                'ajax'    => $this->ajax,
+                'ajax'    => "{$this->ajax}?tableId={$this->tableAttributes['id']}",
                 'columns' => $this->collection->toArray(),
             ]
         );


### PR DESCRIPTION
Hi, I added support for rendering 2 tables in a single page.

The idea was pretty simple. 

I had 2 tables in `/users`, `ActiveUsersDataTable` and `InactiveUsersDataTable`.

- I added and `id` field to use in html part of the datatable so that the ids won't conflict.
- I added `?tableId=TableID` to each request so that we can define which table we're querying with the ajax request to the backend.
- I edited the `server-side.buttons.js` to allow urls with a query parameter.
