### PR TITLE
Adding type GET to minifiedAjax in Html/Builder

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -708,6 +708,7 @@ class Builder
         $appendData = $this->makeDataScript($data);
 
         $this->ajax['url']  = $url;
+        $this->ajax['type'] = 'GET';
         $this->ajax['data'] = "function(data) {
     for (var i = 0, len = data.columns.length; i < len; i++) { 
         if (!data.columns[i].search.value) delete data.columns[i].search;


### PR DESCRIPTION
Hello,

i'm adding type GET to minifiedAjax method in Html/Builder,
because when customizing script.blade.php and using front-end thrid party tools like metronic datatable helper,
the config could be merged with a default one in the process.

The default type was POST in my case so it's not working.
I can always set this in my config, but minifiedAjax is for GET only, so i it's relevant to hard code the type of the request.

Thanks.