### PR TITLE
[3.0] Adding search headers to Html/Builder

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -559,9 +559,10 @@ class Builder
      *
      * @param array $attributes
      * @param bool  $drawFooter
+     * @param bool  $drawSearch
      * @return \Illuminate\Support\HtmlString
      */
-    public function table(array $attributes = [], $drawFooter = false)
+    public function table(array $attributes = [], $drawFooter = false, $drawSearch = false)
     {
         $this->tableAttributes = array_merge($this->getTableAttributes(), $attributes);
 
@@ -569,7 +570,8 @@ class Builder
         $htmlAttr = $this->html->attributes($this->tableAttributes);
 
         $tableHtml = '<table ' . $htmlAttr . '>';
-        $tableHtml .= '<thead><tr>' . implode('', $th) . '</tr></thead>';
+        $searchHtml = $drawSearch ? '<tr class="search-filter">' . implode('', $this->compileTableSearchHeaders()) . '</tr>' : '';
+        $tableHtml .= '<thead><tr>' . implode('', $th) . '</tr>' . $searchHtml . '</thead>';
         if ($drawFooter) {
             $tf        = $this->compileTableFooter();
             $tableHtml .= '<tfoot><tr>' . implode('', $tf) . '</tr></tfoot>';
@@ -623,6 +625,21 @@ class Builder
         }
 
         return $th;
+    }
+    
+    /**
+     * Compile table search headers
+     *
+     * @return array
+     */
+    private function compileTableSearchHeaders()
+    {
+        $search = [];
+        foreach ($this->collection->all() as $key => $row) {
+            $search[] = $row['searchable'] ? '<th>' . (isset($row->search) ? $row->search : '') . '</th>' : '<th></th>';
+        }
+
+        return $search;
     }
 
     /**


### PR DESCRIPTION
hello,

i'm adding search headers to Html/Builder.
it will generate a second row in thead for search filters.
it's the same behaviour as drawFooter :

`$dataTable->table(['id' => 'test'], true, true)`

i don't know if it's a wanted feature or not, so it's more like a proposal.

thanks.