### PR TITLE
[2.0] Remove support for yajra/laravel-datatables-oracle v8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "yajra/laravel-datatables-oracle": "7.*|8.*",
+    "yajra/laravel-datatables-oracle": "7.*",
     "laravelcollective/html": "5.4.*|5.5.*"
   },
   "require-dev": {


### PR DESCRIPTION
since the namespace has been changed from Datatables to DataTables

code conflict:
https://github.com/yajra/laravel-datatables/blob/b1fcc9be3403394791541ec839e1d89f3196e337/src/DataTables.php#L128