### PR TITLE
Review tableAttributes getter and setter

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -89,6 +89,7 @@ class Builder
         $this->view       = $view;
         $this->html       = $html;
         $this->collection = new Collection;
+        $this->tableAttributes = $this->config->get('datatables-html.table', []);
     }
 
     /**
@@ -189,9 +190,7 @@ class Builder
      */
     public function getTableAttributes()
     {
-        $default = $this->config->get('datatables-html.table', ['class' => 'table', 'id' => 'dataTableBuilder']);
-
-        return array_merge($default, $this->tableAttributes);
+        return $this->tableAttributes;
     }
 
     /**

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -117,7 +117,7 @@ class Builder
         $parameters = $this->generateJson();
 
         return new HtmlString(
-            sprintf($this->template(), $this->getTableAttributes()['id'], $parameters)
+            sprintf($this->template(), $this->getTableAttribute('id'), $parameters)
         );
     }
 

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -464,7 +464,7 @@ class Builder
      */
     public function table(array $attributes = [], $drawFooter = false, $drawSearch = false)
     {
-        $this->tableAttributes = array_merge($this->getTableAttributes(), $attributes);
+        $this->setTableAttributes($attributes);
 
         $th       = $this->compileTableHeaders();
         $htmlAttr = $this->html->attributes($this->tableAttributes);

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -202,7 +202,7 @@ class Builder
     public function setTableAttributes(array $attributes)
     {
         foreach ($attributes as $attribute => $value) {
-            $this->setTableAttribute($attribute, $value);
+            $this->tableAttributes[$attribute] = $value;
         }
 
         return $this;
@@ -218,10 +218,10 @@ class Builder
     public function setTableAttribute($attribute, $value = null)
     {
         if (is_array($attribute)) {
-            $this->setTableAttributes($attribute);
-        } else {
-            $this->tableAttributes[$attribute] = $value;
+            return $this->setTableAttributes($attribute);
         }
+
+        $this->tableAttributes[$attribute] = $value;
 
         return $this;
     }

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -10,8 +10,7 @@ class HtmlBuilderTest extends TestCase
 {
     public function test_generate_table_html()
     {
-        $builder = $this->getHtmlBuilder();
-        $builder->config->shouldReceive('get')->andReturn([
+        $builder = $this->getHtmlBuilder([
             'class' => 'table',
             'id'    => 'dataTableBuilder',
         ]);
@@ -46,21 +45,20 @@ class HtmlBuilderTest extends TestCase
     /**
      * @return \Mockery\MockInterface|\Yajra\DataTables\Html\Builder
      */
-    protected function getHtmlBuilder()
+    protected function getHtmlBuilder($config = [])
     {
-        $builder = app('datatables.html');
+        $builder = app('datatables.html', $config);
 
         return $builder;
     }
 
     public function test_generate_table_html_with_empty_footer()
     {
-        $builder = $this->getHtmlBuilder();
-        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
-        $builder->config->shouldReceive('get')->andReturn([
+        $builder = $this->getHtmlBuilder([
             'class' => 'table',
             'id'    => 'dataTableBuilder',
         ]);
+        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
 
         $builder->columns(['foo', 'bar' => ['data' => 'foo']])
                 ->addCheckbox(['id' => 'foo'])
@@ -89,12 +87,11 @@ class HtmlBuilderTest extends TestCase
 
     public function test_generate_table_html_with_footer_content()
     {
-        $builder = $this->getHtmlBuilder();
-        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
-        $builder->config->shouldReceive('get')->andReturn([
+        $builder = $this->getHtmlBuilder([
             'class' => 'table',
             'id'    => 'dataTableBuilder',
         ]);
+        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
 
         $builder->columns(['foo', 'bar' => ['data' => 'foo']])
                 ->addCheckbox(['id' => 'foo', 'footer' => 'test'])

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -4,12 +4,15 @@ use Mockery as m;
 use Yajra\DataTables\Factory;
 use Yajra\DataTables\Html\Builder;
 
-function app($instance)
+function app($instance, $config = [])
 {
     switch ($instance) {
         case 'datatables.html':
+            $configMock = m::mock('Illuminate\Contracts\Config\Repository');
+            $configMock->shouldReceive('get')->andReturn($config);
+
             return new Builder(
-                m::mock('Illuminate\Contracts\Config\Repository'),
+                $configMock,
                 m::mock('Illuminate\Contracts\View\Factory'),
                 m::mock('Collective\Html\HtmlBuilder')
             );


### PR DESCRIPTION
There is already a `'datatables-html.table'` configuration, and it has been merged in service provider, we can safely use it.

If someone configured incorrect attributes, failure or exception would be fine to let him easily find  out mistakes.