### PR TITLE
Add option to use global builder attributes from config

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -89,6 +89,7 @@ class Builder
         $this->view       = $view;
         $this->html       = $html;
         $this->collection = new Collection;
+        $this->attributes = config('datatables-html.builder-attributes', []);
     }
 
     /**
@@ -554,7 +555,7 @@ class Builder
         $this->ajax['type'] = 'GET';
         if (isset($this->attributes['serverSide']) ? $this->attributes['serverSide'] : true) {
             $this->ajax['data'] = "function(data) {
-            for (var i = 0, len = data.columns.length; i < len; i++) { 
+            for (var i = 0, len = data.columns.length; i < len; i++) {
                 if (!data.columns[i].search.value) delete data.columns[i].search;
                 if (data.columns[i].searchable === true) delete data.columns[i].searchable;
                 if (data.columns[i].orderable === true) delete data.columns[i].orderable;

--- a/src/resources/config/config.php
+++ b/src/resources/config/config.php
@@ -8,4 +8,11 @@ return [
         'class' => 'table',
         'id'    => 'dataTableBuilder',
     ],
+
+    /*
+     * Default table builder attributes
+     */
+    'builder-attributes' => [
+        //
+    ],
 ];


### PR DESCRIPTION
Especially helpful in situations where one may need to apply the same settings across all datatables.

I named the attributes array `builder-attributes`, but if there's a better fitting name I can change it.