### PR TITLE
Add addTableClass, removeTableClass to Html Builder

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -5,6 +5,7 @@ namespace Yajra\DataTables\Html;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -241,6 +242,43 @@ class Builder
         }
 
         return $this->tableAttributes[$attribute];
+    }
+
+    /**
+     * Add class names to the "class" attribute of HTML table.
+     *
+     * @param string|array $class
+     * @return $this
+     */
+    public function addTableClass($class)
+    {
+        $class = is_array($class) ? implode(' ', $class) : $class;
+        $currentClass = Arr::get(array_change_key_case($this->tableAttributes), 'class');
+
+        $classes = preg_split('#\s+#', $currentClass.' '.$class, null, PREG_SPLIT_NO_EMPTY);
+        $class = implode(' ', array_unique($classes));
+
+        return $this->setTableAttribute('class', $class);
+    }
+
+    /**
+     * Remove class names from the "class" attribute of HTML table.
+     *
+     * @param string|array $class
+     * @return $this
+     */
+    public function removeTableClass($class)
+    {
+        $class = is_array($class) ? implode(' ', $class) : $class;
+        $currentClass = Arr::get(array_change_key_case($this->tableAttributes), 'class');
+
+        $classes = array_diff(
+            preg_split('#\s+#', $currentClass, null, PREG_SPLIT_NO_EMPTY),
+            preg_split('#\s+#', $class, null, PREG_SPLIT_NO_EMPTY)
+        );
+        $class = implode(' ', array_unique($classes));
+
+        return $this->setTableAttribute('class', $class);
     }
 
     /**

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -149,6 +149,35 @@ class HtmlBuilderTest extends TestCase
         $builder->getTableAttribute('boohoo');
     }
 
+    public function test_adding_table_class_attribute()
+    {
+        $builder = $this->getHtmlBuilder();
+
+        $builder->addTableClass('foo');
+        $this->assertEquals('foo', $builder->getTableAttribute('class'));
+
+        $builder->addTableClass('  foo  bar  ');
+        $this->assertEquals('foo bar', $builder->getTableAttribute('class'));
+
+        $builder->addTableClass([' a-b ', 'foo c bar', 'key' => 'value']);
+        $this->assertEquals('foo bar a-b c value', $builder->getTableAttribute('class'));
+    }
+
+    public function test_removing_table_class_attribute()
+    {
+        $builder = $this->getHtmlBuilder();
+        $builder->setTableAttribute('class', ' foo  bar  a  b  c ');
+
+        $builder->removeTableClass('bar');
+        $this->assertEquals('foo a b c', $builder->getTableAttribute('class'));
+
+        $builder->removeTableClass('  x  c  y ');
+        $this->assertEquals('foo a b', $builder->getTableAttribute('class'));
+
+        $builder->removeTableClass(['a' => ' b ', ' foo  bar ']);
+        $this->assertEquals('a', $builder->getTableAttribute('class'));
+    }
+
     /**
      * @return \Yajra\DataTables\Factory
      */


### PR DESCRIPTION
This PR provides a convenient way to change table class for a certain dataTable, without touching the global configured table classes.