### PR TITLE
Add postAjax() to Html Builder

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -504,6 +504,28 @@ class Builder
     }
 
     /**
+     * Setup "ajax" parameter with POST method.
+     *
+     * @param  string|array  $attributes
+     * @return $this
+     */
+    public function postAjax($attributes = [])
+    {
+        if (! is_array($attributes)) {
+            $attributes = ['url' => (string) $attributes];
+        }
+
+        if (app()->bound('session') && $token = app('session')->token()) {
+            $attributes = Arr::add($attributes, 'headers.X-CSRF-TOKEN', $token);
+        }
+
+        return $this->ajax(array_merge(
+            Arr::except($attributes, 'method'),
+            ['type' => 'POST']
+        ));
+    }
+
+    /**
      * Generate DataTable's table html.
      *
      * @param array $attributes

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -515,14 +515,11 @@ class Builder
             $attributes = ['url' => (string) $attributes];
         }
 
-        if (app()->bound('session') && $token = app('session')->token()) {
-            $attributes = Arr::add($attributes, 'headers.X-CSRF-TOKEN', $token);
-        }
+        unset($attributes['method']);
+        Arr::set($attributes, 'type', 'POST');
+        Arr::set($attributes, 'headers.X-HTTP-Method-Override', 'GET');
 
-        return $this->ajax(array_merge(
-            Arr::except($attributes, 'method'),
-            ['type' => 'POST']
-        ));
+        return $this->ajax($attributes);
     }
 
     /**

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -509,7 +509,7 @@ class Builder
      * @param  string|array  $attributes
      * @return $this
      */
-    public function postAjax($attributes = [])
+    public function postAjax($attributes = '')
     {
         if (! is_array($attributes)) {
             $attributes = ['url' => (string) $attributes];


### PR DESCRIPTION
As @herzcthu said on https://github.com/yajra/laravel-datatables-html/pull/13#issuecomment-337947000 , `minifiedAjax` does not help for a "very big" table.

I think POST ajax is common as well as GET, so I'd like to add a new method `postAjax()` to the `Html\Builder`, and `postAjax()` has the same API as `ajax()`.

```php
$builder->postAjax();
```

equals:

```php
$builder->ajax([
    'type' => 'POST',
    'headers' => [
        'X-CSRF-TOKEN' => 'xxxxxx',
    ],
]);
```

- Except `type` and `method`, any other options will be merged into the final `ajax` parameter, users are free to set any options for `ajax`.
- Using an empty string for `url` is unnecessary, so I did not fill the default `url` value. If there is a reason to provide a default url, I will add it.
- Adding `X-CSRF-TOKEN` header is a safe way to handle CSRF protection. It does not touch/care `ajax.data`, `ajax.beforeSend`, `jQuery.ajaxPrefilter`, `jQuery.ajaxSetup`, even existing `ajax.headers.X-CSRF-TOKEN`.
