### PR TITLE
Fix Ajax error of URL too long

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -493,12 +493,16 @@ class Builder
     /**
      * Setup ajax parameter.
      *
-     * @param  string|array $attributes
-     * @param  bool         $post
+     * @param  string|array|bool  $attributes
+     * @param  bool               $post
      * @return $this
      */
     public function ajax($attributes = '', $post = false)
     {
+        if (is_bool($attributes)) {
+            list($attributes, $post) = [$this->ajax, $attributes];
+        }
+
         $this->ajax = $post === true ? $this->postAjax($attributes) : $attributes;
 
         return $this;

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -494,13 +494,33 @@ class Builder
      * Setup ajax parameter.
      *
      * @param  string|array $attributes
+     * @param  bool         $post
      * @return $this
      */
-    public function ajax($attributes = '')
+    public function ajax($attributes = '', $post = false)
     {
-        $this->ajax = $attributes;
+        $this->ajax = $post === true ? $this->postAjax($attributes) : $attributes;
 
         return $this;
+    }
+
+    /**
+     * Set ajax method to POST, X-HTTP-Method-Override header to GET.
+     *
+     * @param  string|array  $attributes
+     * @return array
+     */
+    protected function postAjax($attributes)
+    {
+        if (! is_array($attributes)) {
+            $attributes = ['url' => (string) $attributes];
+        }
+
+        unset($attributes['method']);
+        Arr::set($attributes, 'type', 'POST');
+        Arr::set($attributes, 'headers.X-HTTP-Method-Override', 'GET');
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
Ref PR #13 #45 , issue https://github.com/yajra/laravel-datatables/issues/348

This PR adds a POST option to `ajax()` method for Html Builder, to make Ajax request to: sending via POST, handle via GET as usual.

Usage:
```php
$builder->ajax('url', true);

$builder->ajax(true);
```

-- _Updated_ --

You can also use `minifiedAjax` at the same time:
```php
$builder()->minifiedAjax()->ajax(true)
```