### PR TITLE
Some Updates

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables;
 
 use Illuminate\Support\ServiceProvider;
+use Yajra\DataTables\Html\Middleware\SmartDataTables;
 use Collective\Html\HtmlServiceProvider as CollectiveHtml;
 
 class HtmlServiceProvider extends ServiceProvider
@@ -19,6 +20,8 @@ class HtmlServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishAssets();
         }
+
+        $this->app['Illuminate\Contracts\Http\Kernel']->pushMiddleware(SmartDataTables::class);
     }
 
     /**

--- a/src/Middleware/SmartDataTables.php
+++ b/src/Middleware/SmartDataTables.php
@@ -20,18 +20,10 @@ class SmartDataTables
             return $next($request);
         }
 
-        $dataTable = app($request->smartDataTable);
+        $dataTable = app($request->get('smartDataTable'));
 
-        if ($request->ajax() && $request->wantsJson()) {
-            return app()->call([$dataTable, 'ajax']);
-        }
-
-        if ($action = $dataTable->request()->get('action') and in_array($action, $dataTable->getActions())) {
-            if ($action == 'print') {
-                return app()->call([$dataTable, 'printPreview']);
-            }
-
-            return app()->call([$dataTable, $action]);
+        if ($response = $dataTable->render()) {
+        	return $response;
         }
 
         return $next($request);

--- a/src/Middleware/SmartDataTables.php
+++ b/src/Middleware/SmartDataTables.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Yajra\DataTables\Html\Middleware;
+
+use Closure;
+
+class SmartDataTables
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * 
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (!$request->has('smartDataTable')) {
+            return $next($request);
+        }
+
+        $dataTable = app($request->smartDataTable);
+
+        if ($request->ajax() && $request->wantsJson()) {
+            return app()->call([$dataTable, 'ajax']);
+        }
+
+        if ($action = $dataTable->request()->get('action') and in_array($action, $dataTable->getActions())) {
+            if ($action == 'print') {
+                return app()->call([$dataTable, 'printPreview']);
+            }
+
+            return app()->call([$dataTable, $action]);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
- queryString:
We have to be able to see the id of the dataTable by looking at the ajax request, since we might want to handle more than one data tables in one route.

- Custom JS functions:
The code now allows jQuery and JS codes to be printed as literal functions.

- SmartDataTables:
Also we want to specify if the request will be handled from the new SmartDataTables service.

So,
Let me explain what SmartDataTables mean for me. My company uses a s* ton of datatables and I am so tired of copy pasing a new route/method over and over again.

SmartDataTables simply adds a field called `$isSmartDataTable` to the `abstract DataTable` class which is by default `false`. On your child class you can overwrite this.

Ex:
```php
    /**
     * Dynamically detects which DataTable to initialize for backend processing and responds.
     *
     * @var boolean
     */
    protected $isSmartDataTable = true;
```

By doing so you let the dataTable add a `smartDataTable` field to the ajax request which has the value of the class which is a "SmartDataTable". If we were to make a UsersDataTable and mark it as "smart". The query will have a parameter like this: `smartDataTable=App\DataTables\UsersDataTable`.

The next step is to check all web requests via a Middleware if the contain the parameter `smartDataTable`. If they do, we will simply resolve the data table class and respond to it accordingly. (Just like the `render` method does.)

```php
        if (!$request->has('smartDataTable')) {
            return $next($request);
        }

        $dataTable = app($request->smartDataTable);

        if ($request->ajax() && $request->wantsJson()) {
            return app()->call([$dataTable, 'ajax']);
        }
```