### PR TITLE
[3.0] Fix callback check on empty values.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -161,6 +161,10 @@ class Builder
      */
     protected function isCallbackFunction($value, $key)
     {
+        if (empty($value)) {
+            return false;
+        }
+
         return Str::startsWith(trim($value), $this->config->get('datatables-html.callback', ['$', '$.', 'function'])) || Str::contains($key, 'editor');
     }
 


### PR DESCRIPTION
This bug prevented giving an empty array as values. I wanted to disable all buttons on a datatable by specifying `buttons => []` in the builder parameters, but it failed with this check.