### PR TITLE
Fix the default name of index column to follow DT syntax.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -469,7 +469,7 @@ class Builder
      */
     public function addIndex(array $attributes = [])
     {
-        $indexColumn = $this->config->get('datatables.index_column', 'DT_Row_Index');
+        $indexColumn = $this->config->get('datatables.index_column', 'DT_RowIndex');
         $attributes  = array_merge([
             'defaultContent' => '',
             'data'           => $indexColumn,


### PR DESCRIPTION
In relation to https://github.com/yajra/laravel-datatables/pull/1882.

