### PR TITLE
Don't wrap DataTables built in render helpers in callback

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -96,7 +96,6 @@ class Column extends Fluent
      * Check if given key & value is a valid datatables built-in renderer function.
      *
      * @param string $value
-     * @param string $key
      * @return bool
      */
     private function isBuiltInRenderFunction($value)

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Html;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
 
 /**
@@ -63,6 +64,8 @@ class Column extends Fluent
 
         if (is_callable($value)) {
             return $value($parameters);
+        } elseif ($this->isBuiltInRenderFunction($value)) {
+            return $value;
         } elseif ($view->exists($value)) {
             return $view->make($value)->with($parameters)->render();
         }
@@ -87,5 +90,21 @@ class Column extends Fluent
     private function parseRenderAsString($value)
     {
         return "function(data,type,full,meta){return $value;}";
+    }
+
+    /**
+     * Check if given key & value is a valid datatables built-in renderer function.
+     *
+     * @param string $value
+     * @param string $key
+     * @return bool
+     */
+    private function isBuiltInRenderFunction($value)
+    {
+        if (empty($value)) {
+            return false;
+        }
+
+        return Str::startsWith(trim($value), ['$.fn.dataTable.render']);
     }
 }

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -119,6 +119,40 @@ class HtmlBuilderTest extends TestCase
         $this->assertEquals($expected, $builder->generateScripts()->toHtml());
     }
 
+    public function test_generate_table_html_with_render_helpers()
+    {
+        $builder = $this->getHtmlBuilder([
+            'class' => 'table',
+            'id'    => 'dataTableBuilder',
+        ]);
+
+        $builder->html->shouldReceive('attributes')->times(10)->andReturn('id="foo"');
+
+        $builder->columns(['foo', 'bar' => ['data' => 'foo'], 'biz' => ['name' => 'baz']])
+                ->addCheckbox(['id' => 'foo'])
+                ->addColumn(['data' => '1.0000', 'title' => 'Num', 'render' => '$.fn.dataTable.render.number( ",", ".", 2, "" )'])
+                ->addColumn(['data' => '<br/>', 'title' => 'Tex', 'render' => '$.fn.dataTable.render.text()'])
+                ->addAction(['title' => 'Options'])
+                ->ajax('ajax-url')
+                ->parameters(['bFilter' => false]);
+        $table    = $builder->table(['id' => 'foo'])->toHtml();
+        $expected = '<table id="foo"><thead><tr><th id="foo">Foo</th><th id="foo">Bar</th><th id="foo">Biz</th><th id="foo"><input type="checkbox" id="foo"/></th><th id="foo">Num</th><th id="foo">Tex</th><th id="foo">Options</th></tr></thead></table>';
+        $this->assertEquals($expected, $table);
+
+        $builder->view->shouldReceive('make')->times(2)->andReturn($builder->view);
+        $builder->config->shouldReceive('get')->times(2)->andReturn('datatables::script');
+        $template = file_get_contents(__DIR__ . '/../src/resources/views/script.blade.php');
+        $builder->view->shouldReceive('render')->times(2)->andReturn(trim($template));
+        $builder->html->shouldReceive('attributes')->once()->andReturn();
+
+        $script   = $builder->scripts()->toHtml();
+        $expected = '<script>(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"foo","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"baz","data":"biz","title":"Biz","orderable":true,"searchable":true},{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox\" id=\"foo\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"data":"1.0000","title":"Num","render":"$.fn.dataTable.render.number( \",\", \".\", 2, \"\" )","orderable":true,"searchable":true,"name":"1.0000"},{"data":"<br\/>","title":"Tex","render":"$.fn.dataTable.render.text()","orderable":true,"searchable":true,"name":"<br\/>"},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);</script>' . "\n";
+        $this->assertEquals($expected, $script);
+
+        $expected = '(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"foo","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"baz","data":"biz","title":"Biz","orderable":true,"searchable":true},{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox\" id=\"foo\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"data":"1.0000","title":"Num","render":"$.fn.dataTable.render.number( \",\", \".\", 2, \"\" )","orderable":true,"searchable":true,"name":"1.0000"},{"data":"<br\/>","title":"Tex","render":"$.fn.dataTable.render.text()","orderable":true,"searchable":true,"name":"<br\/>"},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);';
+        $this->assertEquals($expected, $builder->generateScripts()->toHtml());
+    }
+
     public function test_setting_table_attribute()
     {
         $builder = $this->getHtmlBuilder();


### PR DESCRIPTION
## Summary of PR
This PR adds detection of the render helper prefix as listed in the [DataTables documentation](https://datatables.net/manual/data/renderers#Built-in-helpers,) and includes a passing test for the resulting rendered JavaScript.

## Summary of problem
I'm trying to format numbers using the [DataTables built-in render helpers](https://datatables.net/manual/data/renderers#Built-in-helpers) when defining my column definitions in the model's `getColumns()` method.

When the javascript for the DataTable is generated, the helper is rendered as wrapped in a callback, instead of using the declared helper as is.
This results in the data being rendered as `[object Object]` in the table, instead of as a 2 decimal place formatted number.

## Code snippets of problem
### PHP column definitions
```php
namespace App\DataTables;
use Yajra\DataTables\Services\DataTable;

class TheDataTable extends DataTable
{
    // ...
    public function html()
    {
        return $this->builder()
            ->columns($this->getColumns())
            ->minifiedAjax()
            ->parameters($this->getBuilderParameters());
    }

    protected function getColumns()
    {
        return [
            'description',
            'price' => [
                'name' => 'price',
                'data'=> 'price',
                'render' => '$.fn.dataTable.render.number( ",", ".", 2, "" )'
            ],
            'date'
        ];
    }
    // ...
}
```

###  Non-working JavaScript for affected column using built-in render helper
```javascript
// ...
{
    "name": "price",
    "data": "price",
    "render": function(data, type, full, meta) {
        return $.fn.dataTable.render.number(",", ".", 2, "");
    },
    "title": "Price",
    "orderable": true,
    "searchable": true
},
// ...
```

### Working JavaScript for affected column using built-in render helper
```javascript
// ...
{
    "name": "price",
    "data": "price",
    "render": $.fn.dataTable.render.number(",", ".", 2, ""),
    "title": "Price",
    "orderable": true,
    "searchable": true
}
// ...
```

(Note: this is my first PR on an open source project - please be kind and let me know if I need to change anything!)