### PR TITLE
[3.0] Add support for DataTables Editor script generation.

### DIFF
--- a/src/Html/Editor.php
+++ b/src/Html/Editor.php
@@ -44,9 +44,20 @@ class Editor
      *
      * @param string $instance
      */
-    public function __construct(string $instance = 'editor')
+    public function __construct($instance = 'editor')
     {
         $this->instance = $instance;
+    }
+
+    /**
+     * Make new Editor instance.
+     *
+     * @param string $instance
+     * @return Editor
+     */
+    public static function make($instance = 'editor')
+    {
+        return new static($instance);
     }
 
     /**

--- a/src/Html/Editor.php
+++ b/src/Html/Editor.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+class Editor
+{
+    /**
+     * @var string
+     */
+    public $instance = 'editor';
+
+    /**
+     * @var string
+     */
+    public $ajax = '';
+
+    /**
+     * @var string
+     */
+    public $table = '';
+
+    /**
+     * @var string
+     */
+    public $fields = '';
+
+    /**
+     * @var array
+     */
+    public $language = [];
+
+    /**
+     * @param $instance
+     * @return $this
+     */
+    public function instance($instance)
+    {
+        $this->instance = $instance;
+
+        return $this;
+    }
+
+    /**
+     * @param string|array $ajax
+     * @return $this
+     */
+    public function ajax($ajax)
+    {
+        $this->ajax = $ajax;
+
+        return $this;
+    }
+
+    /**
+     * @param string $table
+     * @return $this
+     */
+    public function table($table)
+    {
+        $this->table = $table;
+
+        return $this;
+    }
+
+    /**
+     * @param array $fields
+     * @return $this
+     */
+    public function fields(array $fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * @param array $language
+     * @return $this
+     */
+    public function language(array $language)
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor.php
+++ b/src/Html/Editor.php
@@ -35,6 +35,11 @@ class Editor
     public $language = [];
 
     /**
+     * @var string
+     */
+    public $scripts = '';
+
+    /**
      * Editor constructor.
      *
      * @param string $instance
@@ -42,6 +47,18 @@ class Editor
     public function __construct(string $instance = 'editor')
     {
         $this->instance = $instance;
+    }
+
+    /**
+     * Append raw scripts.
+     *
+     * @param string $scripts
+     */
+    public function scripts($scripts)
+    {
+        $this->scripts = $scripts;
+
+        return $this;
     }
 
     /**

--- a/src/Html/Editor.php
+++ b/src/Html/Editor.php
@@ -22,6 +22,11 @@ class Editor
     /**
      * @var string
      */
+    public $template = '';
+
+    /**
+     * @var string
+     */
     public $fields = '';
 
     /**
@@ -40,6 +45,8 @@ class Editor
     }
 
     /**
+     * Set Editor's variable name / instance.
+     *
      * @param $instance
      * @return $this
      */
@@ -51,6 +58,8 @@ class Editor
     }
 
     /**
+     * Set Editor's ajax parameter.
+     *
      * @param string|array $ajax
      * @return $this
      */
@@ -62,6 +71,8 @@ class Editor
     }
 
     /**
+     * Set Editor's table source.
+     *
      * @param string $table
      * @return $this
      */
@@ -73,6 +84,8 @@ class Editor
     }
 
     /**
+     * Set Editor's fields.
+     *
      * @param array $fields
      * @return $this
      */
@@ -84,12 +97,27 @@ class Editor
     }
 
     /**
+     * Set Editor's language.
+     *
      * @param array $language
      * @return $this
      */
     public function language(array $language)
     {
         $this->language = $language;
+
+        return $this;
+    }
+
+    /**
+     * Set Editor's template.
+     *
+     * @param string $template
+     * @return $this
+     */
+    public function template($template)
+    {
+        $this->template = $template;
 
         return $this;
     }

--- a/src/Html/Editor.php
+++ b/src/Html/Editor.php
@@ -7,7 +7,7 @@ class Editor
     /**
      * @var string
      */
-    public $instance = 'editor';
+    public $instance = '';
 
     /**
      * @var string
@@ -28,6 +28,16 @@ class Editor
      * @var array
      */
     public $language = [];
+
+    /**
+     * Editor constructor.
+     *
+     * @param string $instance
+     */
+    public function __construct(string $instance = 'editor')
+    {
+        $this->instance = $instance;
+    }
 
     /**
      * @param $instance

--- a/src/Html/Editor/Checkbox.php
+++ b/src/Html/Editor/Checkbox.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Checkbox extends Field
+{
+    protected $type = 'checkbox';
+
+    /**
+     * Set checkbox separator.
+     *
+     * @param string $separator
+     * @return $this
+     */
+    public function separator($separator = ',')
+    {
+        $this->attributes['separator'] = $separator;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor/DateTime.php
+++ b/src/Html/Editor/DateTime.php
@@ -6,6 +6,12 @@ class DateTime extends Field
 {
     protected $type = 'datetime';
 
+    /**
+     * Set dateTime format.
+     *
+     * @param string $format
+     * @return $this
+     */
     public function format($format)
     {
         $this->attributes['format'] = $format;

--- a/src/Html/Editor/DateTime.php
+++ b/src/Html/Editor/DateTime.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class DateTime extends Field
+{
+    protected $type = 'datetime';
+
+    public function format($format)
+    {
+        $this->attributes['format'] = $format;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
+
+class Field extends Fluent
+{
+    /**
+     * Field type.
+     *
+     * @var string
+     */
+    protected $type = 'text';
+
+    /**
+     * Password constructor.
+     */
+    public function __construct($attributes = [])
+    {
+        $attributes['type'] = $attributes['type'] ?? $this->type;
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * @param string $name
+     * @param string $label
+     * @return Field|Select|Password|DateTime|Checkbox|Radio|Hidden|ReadOnly|TextArea
+     */
+    public static function make($name, $label = '')
+    {
+        if (is_array($name)) {
+            return new static($name);
+        }
+
+        $data = [
+            'name' => $name,
+            'label' => $label ?: Str::title($name)
+        ];
+
+        return new static($data);
+    }
+
+    /**
+     * @param string $label
+     * @return $this
+     */
+    public function label($label)
+    {
+        $this->attributes['label'] = $label;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->attributes['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param string $data
+     * @return $this
+     */
+    public function data($data)
+    {
+        $this->attributes['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->attributes['type'] = $type;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor/Hidden.php
+++ b/src/Html/Editor/Hidden.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Hidden extends Field
+{
+    protected $type = 'hidden';
+}

--- a/src/Html/Editor/Password.php
+++ b/src/Html/Editor/Password.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Password extends Field
+{
+    protected $type = 'password';
+}

--- a/src/Html/Editor/Radio.php
+++ b/src/Html/Editor/Radio.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Radio extends Field
+{
+    protected $type = 'radio';
+}

--- a/src/Html/Editor/ReadOnly.php
+++ b/src/Html/Editor/ReadOnly.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class ReadOnly extends Field
+{
+    protected $type = 'readonly';
+}

--- a/src/Html/Editor/Select.php
+++ b/src/Html/Editor/Select.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Select extends Field
+{
+    protected $type = 'select';
+
+    /**
+     * Set select options.
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->attributes['options'] = $options;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor/TextArea.php
+++ b/src/Html/Editor/TextArea.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class TextArea extends Field
+{
+    protected $type = 'textarea';
+}

--- a/src/resources/config/config.php
+++ b/src/resources/config/config.php
@@ -14,4 +14,14 @@ return [
      * Callbacks needs to start by those terms or they will be casted to string.
      */
     'callback' => ['$', '$.', 'function'],
+
+    /**
+     * Html builder script template.
+     */
+    'script' => 'datatables::script',
+
+    /**
+     * Html builder script template for DataTables Editor integration.
+     */
+    'editor' => 'datatables::editor',
 ];

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -9,6 +9,9 @@
             ajax: '{{$editor->ajax}}',
         @endif
         table: '#{{$editor->table}}',
+        @if($editor->template)
+            template: '{{$editor->template}}',
+        @endif
         fields: @json($editor->fields),
         @if($editor->language)
             i18n: @json($editor->language)

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -1,0 +1,19 @@
+(function(window,$){
+    $.ajaxSetup({headers: {'X-CSRF-TOKEN': '{{csrf_token()}}'}});
+    window.LaravelDataTables = window.LaravelDataTables || {};
+    @if($editor)
+        var {{$editor->instance}} = window.LaravelDataTables["%1$s-editor"] = new $.fn.dataTable.Editor({
+        @if(is_array($editor->ajax))
+            ajax: @json($editor->ajax),
+        @else
+            ajax: '{{$editor->ajax}}',
+        @endif
+        table: '#{{$editor->table}}',
+        fields: @json($editor->fields),
+        @if($editor->language)
+            i18n: @json($editor->language)
+        @endif
+        });
+    @endif
+    window.LaravelDataTables["%1$s"] = $("#%1$s").DataTable(%2$s);
+})(window,jQuery);

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -1,8 +1,8 @@
 (function(window,$){
     $.ajaxSetup({headers: {'X-CSRF-TOKEN': '{{csrf_token()}}'}});
     window.LaravelDataTables = window.LaravelDataTables || {};
-    @if($editor)
-        var {{$editor->instance}} = window.LaravelDataTables["%1$s-editor"] = new $.fn.dataTable.Editor({
+    @foreach($editors as $editor)
+        var {{$editor->instance}} = window.LaravelDataTables["%1$s-{{$editor->instance}}"] = new $.fn.dataTable.Editor({
         @if(is_array($editor->ajax))
             ajax: @json($editor->ajax),
         @else
@@ -14,6 +14,6 @@
             i18n: @json($editor->language)
         @endif
         });
-    @endif
+    @endforeach
     window.LaravelDataTables["%1$s"] = $("#%1$s").DataTable(%2$s);
 })(window,jQuery);

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -17,6 +17,7 @@
             i18n: @json($editor->language)
         @endif
         });
+        {!! $editor->scripts  !!}
     @endforeach
     window.LaravelDataTables["%1$s"] = $("#%1$s").DataTable(%2$s);
 })(window,jQuery);


### PR DESCRIPTION
- Fix script template config key `datatables-html.script`.
- Integrate editor scripts to html builder.
- Add method to `getAjaxUrl()`.

## Example with Buttons Package

```php
    public function html()
    {
        return $this->builder()
                    ->columns($this->getColumns())
                    ->setTableId('users-table')
                    ->minifiedAjax()
                    ->addAction(['width' => '80px'])
                    ->parameters($this->getBuilderParameters())
                    ->editor($this->getEditorFields());
    }


    protected function getEditorFields()
    {
        return [
            Editor\Field::make('name'),
            Editor\Field::make('email'),
            Editor\Password::make('password'),
            Editor\Password::make('password_confirmation', 'Confirm Password'),
        ];
    }
```

## Using Editor instance

```php
    public function html()
    {
        return $this->builder()
                    ->columns($this->getColumns())
                    ->setTableId('users-table')
                    ->minifiedAjax()
                    ->addAction(['width' => '80px'])
                    ->parameters($this->getBuilderParameters())
                    ->editor(Editor::make()->fields($this->getEditorFields()));
    }

    protected function getEditorFields()
    {
        return [
            Editor\Field::make('name'),
            Editor\Field::make('email'),
            Editor\Password::make('password'),
            Editor\Password::make('password_confirmation', 'Confirm Password'),
        ];
    }
```

> Note: We should always call editor method as the last method on chain to make sure that all properties/attributes are properly initialized.