### PR TITLE
Add editor options collection builder.

### DIFF
--- a/src/Html/Editor/Checkbox.php
+++ b/src/Html/Editor/Checkbox.php
@@ -5,17 +5,4 @@ namespace Yajra\DataTables\Html\Editor;
 class Checkbox extends Field
 {
     protected $type = 'checkbox';
-
-    /**
-     * Set checkbox separator.
-     *
-     * @param string $separator
-     * @return $this
-     */
-    public function separator($separator = ',')
-    {
-        $this->attributes['separator'] = $separator;
-
-        return $this;
-    }
 }

--- a/src/Html/Editor/DateTime.php
+++ b/src/Html/Editor/DateTime.php
@@ -5,17 +5,4 @@ namespace Yajra\DataTables\Html\Editor;
 class DateTime extends Field
 {
     protected $type = 'datetime';
-
-    /**
-     * Set dateTime format.
-     *
-     * @param string $format
-     * @return $this
-     */
-    public function format($format)
-    {
-        $this->attributes['format'] = $format;
-
-        return $this;
-    }
 }

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -86,4 +86,43 @@ class Field extends Fluent
 
         return $this;
     }
+
+    /**
+     * Set select options.
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->attributes['options'] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Set checkbox separator.
+     *
+     * @param string $separator
+     * @return $this
+     */
+    public function separator($separator = ',')
+    {
+        $this->attributes['separator'] = $separator;
+
+        return $this;
+    }
+
+    /**
+     * Set dateTime format.
+     *
+     * @param string $format
+     * @return $this
+     */
+    public function format($format)
+    {
+        $this->attributes['format'] = $format;
+
+        return $this;
+    }
 }

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -3,8 +3,8 @@
 namespace Yajra\DataTables\Html\Editor;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 
 class Field extends Fluent
 {
@@ -37,7 +37,7 @@ class Field extends Fluent
         }
 
         $data = [
-            'name'  => $name,
+            'name' => $name,
             'label' => $label ?: Str::title($name),
         ];
 
@@ -89,6 +89,21 @@ class Field extends Fluent
     }
 
     /**
+     * Get options from a model.
+     *
+     * @param mixed $model
+     * @param string $value
+     * @param string $key
+     * @return Field
+     */
+    public function modelOptions($model, $value, $key = 'id')
+    {
+        return $this->options(
+            Options::model($model, $value, $key)
+        );
+    }
+
+    /**
      * Set select options.
      *
      * @param array|mixed $options
@@ -103,6 +118,23 @@ class Field extends Fluent
         $this->attributes['options'] = $options;
 
         return $this;
+    }
+
+    /**
+     * Get options from a table.
+     *
+     * @param mixed $table
+     * @param string $value
+     * @param string $key
+     * @param \Closure $whereCallback
+     * @param string|null $key
+     * @return Field
+     */
+    public function tableOptions($table, $value, $key = 'id', \Closure $whereCallback = null, $connection = null)
+    {
+        return $this->options(
+            Options::table($table, $value, $key, $whereCallback, $connection)
+        );
     }
 
     /**

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Html\Editor;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
 
@@ -90,11 +91,15 @@ class Field extends Fluent
     /**
      * Set select options.
      *
-     * @param array $options
+     * @param array|mixed $options
      * @return $this
      */
-    public function options(array $options)
+    public function options($options)
     {
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
         $this->attributes['options'] = $options;
 
         return $this;

--- a/src/Html/Editor/Options.php
+++ b/src/Html/Editor/Options.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Html\Editor;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class Options extends Collection
@@ -19,6 +20,28 @@ class Options extends Collection
         ];
 
         return new static($data);
+    }
+
+    /**
+     * Get options from a model.
+     *
+     * @param mixed $model
+     * @param string $value
+     * @param string $key
+     * @return Collection
+     */
+    public static function model($model, $value, $key = 'id')
+    {
+        if (!$model instanceof Builder) {
+            $model = $model::query();
+        }
+
+        return $model->get()->map(function($model) use($value, $key) {
+            return [
+                'value' => $model->{$key},
+                'label' => $model->{$value}
+            ];
+        });
     }
 
     /**

--- a/src/Html/Editor/Options.php
+++ b/src/Html/Editor/Options.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables\Html\Editor;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class Options extends Collection
 {
@@ -32,16 +33,39 @@ class Options extends Collection
      */
     public static function model($model, $value, $key = 'id')
     {
-        if (!$model instanceof Builder) {
+        if (! $model instanceof Builder) {
             $model = $model::query();
         }
 
-        return $model->get()->map(function($model) use($value, $key) {
+        return $model->get()->map(function ($model) use ($value, $key) {
             return [
                 'value' => $model->{$key},
-                'label' => $model->{$value}
+                'label' => $model->{$value},
             ];
         });
+    }
+
+    /**
+     * Get options from a model.
+     *
+     * @param mixed $table
+     * @param string $value
+     * @param string $key
+     * @param \Closure $whereCallback
+     * @param string|null $key
+     * @return Collection
+     */
+    public static function table($table, $value, $key = 'id', \Closure $whereCallback = null, $connection = null)
+    {
+        $query = DB::connection($connection)
+                   ->table($table)
+                   ->select("{$value} as label", "{$key} as value");
+
+        if ($whereCallback) {
+            $query->where($whereCallback);
+        }
+
+        return $query->get();
     }
 
     /**

--- a/src/Html/Editor/Options.php
+++ b/src/Html/Editor/Options.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+use Illuminate\Support\Collection;
+
+class Options extends Collection
+{
+    /**
+     * Return a Yes/No options.
+     *
+     * @return Options
+     */
+    public static function yesNo()
+    {
+        $data = [
+            ['label' => __("Yes"), 'value' => true],
+            ['label' => __("No"), 'value' => false],
+        ];
+
+        return new static($data);
+    }
+
+    /**
+     * Return a True/False options.
+     *
+     * @return Options
+     */
+    public static function trueFalse()
+    {
+        $data = [
+            ['label' => __("True"), 'value' => true],
+            ['label' => __("False"), 'value' => false],
+        ];
+
+        return new static($data);
+    }
+
+    /**
+     * Push an item onto the end of the collection.
+     *
+     * @param mixed $value
+     * @param mixed $key
+     * @return Options
+     */
+    public function append($value, $key)
+    {
+        return $this->push(['label' => $value, 'value' => $key]);
+    }
+
+    /**
+     * Push an item onto the beginning of the collection.
+     *
+     * @param  mixed $value
+     * @param  mixed $key
+     * @return $this
+     */
+    public function prepend($value, $key = null)
+    {
+        $data = ['label' => $value, 'value' => $key];
+
+        return parent::prepend($data);
+    }
+}

--- a/src/Html/Editor/Options.php
+++ b/src/Html/Editor/Options.php
@@ -46,7 +46,7 @@ class Options extends Collection
     }
 
     /**
-     * Get options from a model.
+     * Get options from a table.
      *
      * @param mixed $table
      * @param string $value

--- a/src/Html/Editor/Select.php
+++ b/src/Html/Editor/Select.php
@@ -5,17 +5,4 @@ namespace Yajra\DataTables\Html\Editor;
 class Select extends Field
 {
     protected $type = 'select';
-
-    /**
-     * Set select options.
-     *
-     * @param array $options
-     * @return $this
-     */
-    public function options(array $options)
-    {
-        $this->attributes['options'] = $options;
-
-        return $this;
-    }
 }


### PR DESCRIPTION
- Add editor options collection builder.
- Move all setters to Field class.
- Add options source from a model or table.

## Examples

```php
use Yajra\DataTables\Html\Editor;

Editor::make()
      ->fields([
          Editor\Field::make('name'),
          Editor\Field::make('email'),
          Editor\Radio::make('is_admin')->options(Editor\Options::yesNo()),
      ]);

Editor\Radio::make('is_admin')->options(Editor\Options::trueFalse()),

Editor\Options::make()
    ->append('Yes', true)
    ->append('No', false)
    ->prepend('Maybe', null);
```