### PR TITLE
Add new fields, fix dateTime field format.

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -23,7 +23,10 @@ class Column extends Fluent
      */
     public function __construct($attributes = [])
     {
-        $attributes['title']      = isset($attributes['title']) ? $attributes['title'] : Str::title($attributes['data']);
+        $attributes['title'] = isset($attributes['title']) ? $attributes['title'] : Str::title(
+            str_replace('_', ' ', $attributes['data'])
+        );
+
         $attributes['orderable']  = isset($attributes['orderable']) ? $attributes['orderable'] : true;
         $attributes['searchable'] = isset($attributes['searchable']) ? $attributes['searchable'] : true;
         $attributes['exportable'] = isset($attributes['exportable']) ? $attributes['exportable'] : true;

--- a/src/Html/Editor/Boolean.php
+++ b/src/Html/Editor/Boolean.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Boolean extends Select
+{
+    /**
+     * Make a new instance of a field.
+     *
+     * @param string $name
+     * @param string $label
+     * @return Field
+     */
+    public static function make($name, $label = '')
+    {
+        return parent::make($name, $label)->options(Options::trueFalse());
+    }
+}

--- a/src/Html/Editor/Boolean.php
+++ b/src/Html/Editor/Boolean.php
@@ -2,7 +2,7 @@
 
 namespace Yajra\DataTables\Html\Editor;
 
-class Boolean extends Select
+class Boolean extends Checkbox
 {
     /**
      * Make a new instance of a field.
@@ -13,6 +13,8 @@ class Boolean extends Select
      */
     public static function make($name, $label = '')
     {
-        return parent::make($name, $label)->options(Options::trueFalse());
+        return parent::make($name, $label)->separator(',')->options(
+            Options::make()->append('', 1)
+        );
     }
 }

--- a/src/Html/Editor/Date.php
+++ b/src/Html/Editor/Date.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Date extends DateTime
+{
+    /**
+     * Make a new instance of a field.
+     *
+     * @param string $name
+     * @param string $label
+     * @return Field
+     */
+    public static function make($name, $label = '')
+    {
+        return parent::make($name, $label)->format('YYYY-MM-DD');
+    }
+}

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -29,9 +29,11 @@ class Field extends Fluent
     }
 
     /**
+     * Make a new instance of a field.
+     *
      * @param string $name
      * @param string $label
-     * @return Field|Select|Password|DateTime|Checkbox|Radio|Hidden|ReadOnly|TextArea
+     * @return Field
      */
     public static function make($name, $label = '')
     {

--- a/src/Html/Editor/Field.php
+++ b/src/Html/Editor/Field.php
@@ -43,7 +43,7 @@ class Field extends Fluent
 
         $data = [
             'name'  => $name,
-            'label' => $label ?: Str::title($name),
+            'label' => $label ?: Str::title(str_replace('_', ' ', $name)),
         ];
 
         return new static($data);

--- a/src/Html/Editor/Number.php
+++ b/src/Html/Editor/Number.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Number extends Field
+{
+}

--- a/src/Html/Editor/Text.php
+++ b/src/Html/Editor/Text.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor;
+
+class Text extends Field
+{
+}

--- a/src/Html/Editor/Time.php
+++ b/src/Html/Editor/Time.php
@@ -2,20 +2,18 @@
 
 namespace Yajra\DataTables\Html\Editor;
 
-class DateTime extends Field
+class Time extends DateTime
 {
-    protected $type = 'datetime';
-
     /**
      * Make a new instance of a field.
      *
      * @param string $name
      * @param string $label
-     * @return Field|\DateTime
+     * @return Field|Time
      */
     public static function make($name, $label = '')
     {
-        return parent::make($name, $label)->format('YYYY-MM-DD hh:mm a');
+        return parent::make($name, $label)->format('hh:mm a');
     }
 
     /**
@@ -25,6 +23,6 @@ class DateTime extends Field
      */
     public function military()
     {
-        return $this->format('YYYY-MM-DD HH:mm');
+        return $this->format('HH:mm');
     }
 }


### PR DESCRIPTION
## Changed

- Fix field and column computed title.

From `created_at` with title `Created_At`
To `created_at` with title `Created At`

## Fixed
- Fix DateTime field 
- Set format to `YYYY-MM-DD hh:mm a`
- Add `military()` setter to set the time to military format.

## Added New Fields
- Boolean
- Date
- Time
- Text
- Number

