### PR TITLE
[4.0] Add ajaxWithForm api to process dataTables with form data.

### DIFF
--- a/src/Html/Options/HasData.php
+++ b/src/Html/Options/HasData.php
@@ -118,4 +118,23 @@ trait HasData
 
         return $this->ajax ?: url()->current();
     }
+
+    /**
+     * Set ajax url with data added from form.
+     *
+     * @param string $url
+     * @param string $formSelector
+     * @return $this
+     */
+    public function ajaxWithForm($url, $formSelector)
+    {
+        $script = <<<CDATA
+var formData = $("{$formSelector}").find("input, select").serializeArray();
+$.each(formData, function(i, obj){
+    data[obj.name] = obj.value;
+});
+CDATA;
+
+        return $this->minifiedAjax($url, $script);
+    }
 }


### PR DESCRIPTION
-  Add ajaxWithForm api to process dataTables with form data.
- Useful for advance search.

## Example

```php
    public function html()
    {
        return $this->builder()
                    ->columns($this->getColumns())
                    ->ajaxWithForm('', "#search-form") // ajax form data appended.
                    ->dom("<'row'<'col-sm-12 col-md-6'i><'col-sm-12 col-md-6'p>>" .
                        "<'row'<'col-sm-12'tr>>" .
                        "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'p>>")
                    ->orderBy(0)
                    ->searching(false)
                    ->responsive()
                    ->lengthMenu([10, 20, 50, 100])
                    ->pageLength(20)
                    ->buttons()
                    ->columnDefs([
                        ['responsivePriority' => 1, 'targets' => [0, 3]],
                    ]);
    }
```