### PR TITLE
[4.0] Avoid call parseRender when render attribute is null.

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -34,7 +34,7 @@ class Column extends Fluent
         // Allow methods override attribute value
         foreach ($attributes as $attribute => $value) {
             $method = 'parse' . ucfirst(strtolower($attribute));
-            if (method_exists($this, $method)) {
+            if (! is_null($value) && method_exists($this, $method)) {
                 $attributes[$attribute] = $this->$method($value);
             }
         }


### PR DESCRIPTION
## Actual Behavior.
Currently, when the action column is added in the Builder, the render attribute is set to null, and the parseRender method is called in the Column class constructor. This commit adds a little validation to avoid calling parseRender and all the methods called inside this method.