### PR TITLE
[4.0] Add title attribute for table headers.

### DIFF
--- a/src/Html/HasTable.php
+++ b/src/Html/HasTable.php
@@ -123,7 +123,7 @@ trait HasTable
         $th = [];
         foreach ($this->collection->toArray() as $row) {
             $thAttr = $this->html->attributes(array_merge(
-                array_only($row, ['class', 'id', 'width', 'style', 'data-class', 'data-hide']),
+                array_only($row, ['class', 'id', 'title', 'width', 'style', 'data-class', 'data-hide']),
                 $row['attributes']
             ));
             $th[] = '<th ' . $thAttr . '>' . $row['title'] . '</th>';
@@ -158,7 +158,7 @@ trait HasTable
         foreach ($this->collection->all() as $row) {
             if (is_array($row->footer)) {
                 $footerAttr = $this->html->attributes(array_only($row->footer,
-                    ['class', 'id', 'width', 'style', 'data-class', 'data-hide']));
+                    ['class', 'id', 'title', 'width', 'style', 'data-class', 'data-hide']));
                 $title = isset($row->footer['title']) ? $row->footer['title'] : '';
                 $footer[] = '<th ' . $footerAttr . '>' . $title . '</th>';
             } else {


### PR DESCRIPTION
This is useful when the column name does not fully fit the dimensions of the column.