### PR TITLE
[4.0] Add ability to generate dataTables options for external js use.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -264,4 +264,16 @@ class Builder
 
         return $script;
     }
+
+    /**
+     * Generate scripts that sets the dataTables options into a variable.
+     *
+     * @return $this
+     */
+    public function asOptions()
+    {
+        $this->setTemplate('datatables::options');
+
+        return $this;
+    }
 }

--- a/src/Html/Editor/Fields/Field.php
+++ b/src/Html/Editor/Fields/Field.php
@@ -298,4 +298,17 @@ class Field extends Fluent
 
         return $this;
     }
+
+    /**
+     * Set field opts value.
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function opts(array $value)
+    {
+        $this->attributes['opts'] = $value;
+
+        return $this;
+    }
 }

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -2,7 +2,7 @@
     $.ajaxSetup({headers: {'X-CSRF-TOKEN': '{{csrf_token()}}'}});
     window.LaravelDataTables = window.LaravelDataTables || {};
     @foreach($editors as $editor)
-        var {{$editor->instance}} = window.LaravelDataTables["%1$s-{{$editor->instance}}"] = new $.fn.dataTable.Editor(@json($editor));
+        var {{$editor->instance}} = window.LaravelDataTables["%1$s-{{$editor->instance}}"] = new $.fn.dataTable.Editor({!! $editor->toJson() !!});
         {!! $editor->scripts  !!}
         @foreach ((array) $editor->events as $event)
             {{$editor->instance}}.on('{!! $event['event']  !!}', {!! $event['script'] !!});

--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -2,27 +2,7 @@
     $.ajaxSetup({headers: {'X-CSRF-TOKEN': '{{csrf_token()}}'}});
     window.LaravelDataTables = window.LaravelDataTables || {};
     @foreach($editors as $editor)
-        var {{$editor->instance}} = window.LaravelDataTables["%1$s-{{$editor->instance}}"] = new $.fn.dataTable.Editor({
-        @if(is_array($editor->ajax))
-            ajax: @json($editor->ajax),
-        @else
-            ajax: "{{$editor->ajax}}",
-        @endif
-        table: "#{{$editor->table}}",
-        @if($editor->template)
-            template: "{{$editor->template}}",
-        @endif
-        @if($editor->display)
-            display: "{{$editor->display}}",
-        @endif
-        @if($editor->idSrc)
-            idSrc: "{{$editor->idSrc}}",
-        @endif
-        fields: @json($editor->fields),
-        @if($editor->language)
-            i18n: @json($editor->language)
-        @endif
-        });
+        var {{$editor->instance}} = window.LaravelDataTables["%1$s-{{$editor->instance}}"] = new $.fn.dataTable.Editor(@json($editor));
         {!! $editor->scripts  !!}
         @foreach ((array) $editor->events as $event)
             {{$editor->instance}}.on('{!! $event['event']  !!}', {!! $event['script'] !!});

--- a/src/resources/views/options.blade.php
+++ b/src/resources/views/options.blade.php
@@ -1,0 +1,6 @@
+window.LaravelDataTables = window.LaravelDataTables || {};
+window.LaravelDataTables.options = %2$s
+window.LaravelDataTables.editors = [];
+@foreach($editors as $editor)
+window.LaravelDataTables.editors["{{$editor->instance}}"] = {!! $editor->toJson()  !!}
+@endforeach


### PR DESCRIPTION
This PR will add an ability to generate dataTables options for external js use.

- Add undocumented / missing opts option setter.
- Add asOption api to generate dataTables scripts.
- Add toArray and toJson serializer for Editor class.