### PR TITLE
Fix language key and use i18n.

### DIFF
--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -145,7 +145,7 @@ class Editor extends Fluent
      */
     public function language(array $language)
     {
-        $this->attributes['language'] = $language;
+        $this->attributes['i18n'] = $language;
 
         return $this;
     }


### PR DESCRIPTION
#102 fix language function to setting 'i18n' instead 'language' attribute for building Editor translation according to https://editor.datatables.net/reference/option/i18n .

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-html/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
