### PR TITLE
[4.0] Add select2 ajax option support.

### DIFF
--- a/src/Html/Editor/Fields/Select2.php
+++ b/src/Html/Editor/Fields/Select2.php
@@ -34,4 +34,84 @@ class Select2 extends Select
 
         return $this;
     }
+
+    /**
+     * Set select2 ajax option.
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function ajax($value)
+    {
+        $this->attributes['opts']['ajax']['url'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set select2 ajaxDelay option.
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function ajaxDelay($value = 250)
+    {
+        $this->attributes['opts']['ajax']['delay'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set select2 ajax data option.
+     *
+     * @param mixed $data
+     * @return $this
+     */
+    public function ajaxData($data)
+    {
+        if (is_array($data)) {
+            $script = 'function(params) {';
+            foreach ($data as $key => $value) {
+                $script .= " params.{$key} = '{$value}'; ";
+            }
+            $script .= 'return params; }';
+
+            $data = $script;
+        }
+
+        $this->attributes['opts']['ajax']['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set select2 ajax processResults option to process a paginated results.
+     *
+     * @param string $display
+     * @param string $id
+     * @return $this
+     */
+    public function processPaginatedResults($display = 'text', $id = 'id')
+    {
+        $script = 'function(data, params) { ';
+        $script .= 'params.page = params.page || 1; ';
+        $script .= "data.data.map(function(e) { e.text = e.{$display}; e.id = e.{$id}; return e; }); ";
+        $script .= 'return { results: data.data, pagination: { more: data.current_page < data.last_page } };';
+        $script .= '}';
+
+        return $this->processResults($script);
+    }
+
+    /**
+     * Set select2 ajax processResults option.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function processResults($value)
+    {
+        $this->attributes['opts']['ajax']['processResults'] = $value;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## Requirements

https://editor.datatables.net/plug-ins/field-type/editor.select2

## Editor

```php
->fields([
Fields\Select2::make('user_id')
  ->ajax(route('api.users'))
  ->ajaxData(['company_id' => 1]) // appends company_id = 1 to the request
  ->ajaxDelay(250)
  ->processPaginatedResults('name', 'id') // name: the column to be used for display
])
```

## API

```php
// routes/api.php

Route::get('users', function () {
    $query = User::query();

    if ($q = request('term')) {
        $query->where('name', 'like', "%{$q}%");
    }

    return $query->paginate();
})->name('api.users');

```
