### PR TITLE
Improve adding custom action to buttons.

### DIFF
--- a/src/Html/Button.php
+++ b/src/Html/Button.php
@@ -172,7 +172,9 @@ class Button extends Fluent implements Arrayable
      */
     public function actionSubmit()
     {
-        return $this->action('function() { this.submit(); }');
+        $this->attributes['action'] = 'function() { this.submit(); }';
+
+        return $this;
     }
 
     /**
@@ -183,7 +185,7 @@ class Button extends Fluent implements Arrayable
      */
     public function action($value)
     {
-        $this->attributes['action'] = $value;
+        $this->attributes['action'] = "function(e, dt, node, config) { $value }";
 
         return $this;
     }
@@ -196,7 +198,9 @@ class Button extends Fluent implements Arrayable
      */
     public function actionHandler($action)
     {
-        return $this->action("function() { this.submit(null, null, function(data) { data.action = '{$action}'; return data; }) }");
+        $this->attributes['action'] = "function() { this.submit(null, null, function(data) { data.action = '{$action}'; return data; }) }";
+
+        return $this;
     }
 
     /**
@@ -206,6 +210,8 @@ class Button extends Fluent implements Arrayable
      */
     public function actionClose()
     {
-        return $this->action('function() { this.close(); }');
+        $this->attributes['action'] = 'function() { this.close(); }';
+
+        return $this;
     }
 }

--- a/src/Html/Button.php
+++ b/src/Html/Button.php
@@ -185,7 +185,11 @@ class Button extends Fluent implements Arrayable
      */
     public function action($value)
     {
-        $this->attributes['action'] = "function(e, dt, node, config) { $value }";
+        if (substring($value, 0, 8) == 'function') {
+            $this->attributes['action'] = $value;
+        } else {
+            $this->attributes['action'] = "function(e, dt, node, config) { $value }";
+        }
 
         return $this;
     }


### PR DESCRIPTION
Improve adding custom action to buttons.

For example I want add a button with custom action but this package not supported that. After this pull request, everybody can button with custom action using via like following code:

File: `app/Datatables/UsersDataTable.php`
```
...
public function html()
    {
        return $this->builder()
            ->setTableId('usersdatatable-table')
            ->columns($this->getColumns())
            ->minifiedAjax()
            ->dom('Bfrtip')
            ->orderBy(0)
            ->buttons(
                (new Button)->text('Button Test')->action('alert("clicked!")')
            );
    }
...
```

Btw, I supported before this PR codes. So this PR not broke older codes.