### PR TITLE
Fixed @return types, allowing for better type hinting when the Column class is extended

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -54,7 +54,7 @@ class Column extends Fluent
      *
      * @param string $data
      * @param string $title
-     * @return Column
+     * @return static
      */
     public static function computed($data, $title = '')
     {
@@ -105,7 +105,7 @@ class Column extends Fluent
      *
      * @param string $data
      * @param string $name
-     * @return Column
+     * @return static
      */
     public static function make($data, $name = '')
     {
@@ -121,7 +121,7 @@ class Column extends Fluent
      * Create a checkbox column.
      *
      * @param string $title
-     * @return Column
+     * @return static
      */
     public static function checkbox($title = '')
     {


### PR DESCRIPTION
Minor update. Some return types were hardcoded to the default Column class. This caused type hinting to break when a different class, i.e. MyColumn with some additional fluent methods, extended the Column class. Corrected by updating return types to static.

(Using version 3 on purpose for compatibility with OctoberCMS.)