### PR TITLE
[4.0] Use full url on ajax if not set.

### DIFF
--- a/src/Html/Options/HasData.php
+++ b/src/Html/Options/HasData.php
@@ -77,7 +77,7 @@ trait HasData
         $this->ajax = [];
         $appendData = $this->makeDataScript($data);
 
-        $this->ajax['url'] = empty($url) ? url()->current() : $url;
+        $this->ajax['url'] = empty($url) ? url()->full() : $url;
         $this->ajax['type'] = 'GET';
         if (isset($this->attributes['serverSide']) ? $this->attributes['serverSide'] : true) {
             $this->ajax['data'] = 'function(data) {


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-datatables/issues/2322.
Fix #121 

