### PR TITLE
Apply camelCase to assumed column name attrib if it contains relation

### DIFF
--- a/src/Html/Options/HasColumns.php
+++ b/src/Html/Options/HasColumns.php
@@ -27,6 +27,15 @@ trait HasColumns
         return $this;
     }
 
+    private function camelRelation($column)
+    {
+
+        $parts      = explode('.', $column);
+        $columnName = array_pop($parts);
+        $relation   = Str::camel(implode('.', $parts));
+
+        return $relation . ($relation ? '.' : '') . $columnName;
+    }
     /**
      * Set columns option value.
      *
@@ -43,14 +52,14 @@ trait HasColumns
                 if (is_array($value)) {
                     $attributes = array_merge(
                         [
-                            'name' => $value['name'] ?? $value['data'] ?? $key,
+                            'name' => $value['name'] ?? $this->camelRelation($value['data'] ?? $key),
                             'data' => $value['data'] ?? $key,
                         ],
                         $this->setTitle($key, $value)
                     );
                 } else {
                     $attributes = [
-                        'name' => $value,
+                        'name' => $this->camelRelation($value),
                         'data' => $value,
                         'title' => $this->getQualifiedTitle($value),
                     ];


### PR DESCRIPTION
When database columns contain values that include a relation with snake case, e.g. "child_table.column", and the Eloquent model has the relation named using the Laravel default of camel case  (e.g.  childTable ).. the datatable global search will fail because the search query builder fails to find "child_table" within the EagerLoads for the model as it is named in the EagerLoad array as "childTable", leading to SQL query failure because the query does not add the required sub-query. 

The docs at https://datatables.yajrabox.com/eloquent/relationships note this can be avoided by explicitly specifying the name attribute separately from the value, but this PR offers that the column building routine should assume camelCase for relations when no name attribute is explicitly specified in the columns array, as the majority of projects probably will follow that convention.
