### PR TITLE
HTML title for columns labels

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -510,9 +510,9 @@ class Column extends Fluent
      * @param mixed $value
      * @return $this
      */
-    public function htmlTitle($value)
+    public function titleAttr($value)
     {
-        $this->attributes['html-title'] = $value;
+        $this->attributes['titleAttr'] = $value;
 
         return $this;
     }

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -505,6 +505,19 @@ class Column extends Fluent
     }
 
     /**
+     * Set custom html title instead defult label.
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function htmlTitle($value)
+    {
+        $this->attributes['html-title'] = $value;
+
+        return $this;
+    }
+    
+    /**
      * @return array
      */
     public function toArray()

--- a/src/Html/HasTable.php
+++ b/src/Html/HasTable.php
@@ -124,7 +124,8 @@ trait HasTable
         foreach ($this->collection->toArray() as $row) {
             $thAttr = $this->html->attributes(array_merge(
                 Arr::only($row, ['class', 'id', 'title', 'width', 'style', 'data-class', 'data-hide']),
-                $row['attributes']
+                $row['attributes'],
+                isset($row['html-title']) ? ['title' => $row['html-title']] : [],
             ));
             $th[] = '<th ' . $thAttr . '>' . $row['title'] . '</th>';
         }

--- a/src/Html/HasTable.php
+++ b/src/Html/HasTable.php
@@ -125,7 +125,7 @@ trait HasTable
             $thAttr = $this->html->attributes(array_merge(
                 Arr::only($row, ['class', 'id', 'title', 'width', 'style', 'data-class', 'data-hide']),
                 $row['attributes'],
-                isset($row['html-title']) ? ['title' => $row['html-title']] : [],
+                isset($row['titleAttr']) ? ['title' => $row['titleAttr']] : [],
             ));
             $th[] = '<th ' . $thAttr . '>' . $row['title'] . '</th>';
         }


### PR DESCRIPTION
A simple update to allow set custom HTML title instead auto-generated from "title". 

Usage:
`Column::computed('image')->title('')->htmlTitle('User image thumb');`

