### PR TITLE
[4.0] Add support for search panes extension.

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -5,6 +5,7 @@ namespace Yajra\DataTables\Html;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
+use Yajra\DataTables\Html\Options\Plugins\SearchPanes;
 
 /**
  * @property string data
@@ -19,6 +20,8 @@ use Illuminate\Support\Fluent;
  */
 class Column extends Fluent
 {
+    use SearchPanes;
+
     /**
      * @param array $attributes
      */
@@ -101,7 +104,7 @@ class Column extends Fluent
 
         return $this;
     }
-    
+
      /**
      * Set column responsive priority.
      *

--- a/src/Html/ColumnDefinition.php
+++ b/src/Html/ColumnDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use Illuminate\Support\Fluent;
+
+class ColumnDefinition extends Fluent
+{
+    use HasOptions;
+
+    public function targets($value)
+    {
+        $this->attributes['targets'] = (array) $value;
+
+        return $this;
+    }
+}

--- a/src/Html/ColumnDefinitions.php
+++ b/src/Html/ColumnDefinitions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use Illuminate\Support\Collection;
+
+class ColumnDefinitions extends Collection
+{
+
+}

--- a/src/Html/HasOptions.php
+++ b/src/Html/HasOptions.php
@@ -27,6 +27,7 @@ trait HasOptions
     use Options\Plugins\RowReorder;
     use Options\Plugins\Scroller;
     use Options\Plugins\Select;
+    use Options\Plugins\SearchPanes;
 
     /**
      * Set deferLoading option value.

--- a/src/Html/Options/HasColumns.php
+++ b/src/Html/Options/HasColumns.php
@@ -5,6 +5,7 @@ namespace Yajra\DataTables\Html\Options;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Yajra\DataTables\Html\Column;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * DataTables - Columns option builder.
@@ -16,13 +17,43 @@ trait HasColumns
     /**
      * Set columnDefs option value.
      *
-     * @param array $value
+     * @param mixed $value
      * @return $this
      * @see https://datatables.net/reference/option/columnDefs
      */
-    public function columnDefs(array $value)
+    public function columnDefs($value)
     {
+        if (is_callable($value)) {
+            $value = app()->call($value);
+        }
+
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
+        }
+
         $this->attributes['columnDefs'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add a columnDef option.
+     *
+     * @param mixed $value
+     * @return $this
+     * @see https://datatables.net/reference/option/columnDefs
+     */
+    public function addColumnDef($value)
+    {
+        if (is_callable($value)) {
+            $value = app()->call($value);
+        }
+
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
+        }
+
+        $this->attributes['columnDefs'][] = $value;
 
         return $this;
     }

--- a/src/Html/Options/Plugins/SearchPanes.php
+++ b/src/Html/Options/Plugins/SearchPanes.php
@@ -2,7 +2,7 @@
 
 namespace Yajra\DataTables\Html\Options\Plugins;
 
-use Yajra\DataTables\Html\SearchPane;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * DataTables - Search panes plugin option builder.
@@ -21,11 +21,11 @@ trait SearchPanes
      */
     public function searchPanes($value = true)
     {
-        if ($value instanceof SearchPane) {
-            $this->attributes['searchPane'] = $value->toArray();
-        } else {
-            $this->attributes['searchPane'] = $value;
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
         }
+
+        $this->attributes['searchPanes'] = $value;
 
         return $this;
     }

--- a/src/Html/Options/Plugins/SearchPanes.php
+++ b/src/Html/Options/Plugins/SearchPanes.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Html\Options\Plugins;
 
+use Yajra\DataTables\Html\SearchPane;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
@@ -21,8 +22,16 @@ trait SearchPanes
      */
     public function searchPanes($value = true)
     {
+        if (is_callable($value)) {
+            $value = app()->call($value);
+        }
+
         if ($value instanceof Arrayable) {
             $value = $value->toArray();
+        }
+
+        if (is_bool($value)) {
+            $value = SearchPane::make()->show($value)->toArray();
         }
 
         $this->attributes['searchPanes'] = $value;

--- a/src/Html/Options/Plugins/SearchPanes.php
+++ b/src/Html/Options/Plugins/SearchPanes.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Yajra\DataTables\Html\Options\Plugins;
+
+use Yajra\DataTables\Html\SearchPane;
+
+/**
+ * DataTables - Search panes plugin option builder.
+ *
+ * @see https://datatables.net/extensions/searchpanes
+ * @see https://datatables.net/reference/option/searchPanes
+ */
+trait SearchPanes
+{
+    /**
+     * Set searchPane option value.
+     *
+     * @param bool|array $value
+     * @return $this
+     * @see https://datatables.net/reference/option/searchPanes
+     */
+    public function searchPanes($value = true)
+    {
+        if ($value instanceof SearchPane) {
+            $this->attributes['searchPane'] = $value->toArray();
+        } else {
+            $this->attributes['searchPane'] = $value;
+        }
+
+        return $this;
+    }
+}

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -158,4 +158,28 @@ class SearchPane extends Fluent
 
         return $this;
     }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.threshold
+     */
+    public function threshold($value)
+    {
+        $this->attributes['threshold'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param boolean $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.viewTotal
+     */
+    public function viewTotal($value = true)
+    {
+        $this->attributes['viewTotal'] = $value;
+
+        return $this;
+    }
 }

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -195,6 +195,18 @@ class SearchPane extends Fluent
     }
 
     /**
+     * @param boolean $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.viewTotal
+     */
+    public function hideTotal($value = true)
+    {
+        $this->attributes['viewTotal'] = ! $value;
+
+        return $this;
+    }
+
+    /**
      * Get options from a model.
      *
      * @param mixed $model

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -289,4 +289,16 @@ class SearchPane extends Fluent
 
         return $this;
     }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/columns.searchPanes.orthogonal
+     */
+    public function orthogonal($value)
+    {
+        $this->attributes['orthogonal'] = $value;
+
+        return $this;
+    }
 }

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -267,13 +267,25 @@ class SearchPane extends Fluent
     }
 
     /**
-     * @param mixed $value
+     * @param bool $value
      * @return static
      * @see https://datatables.net/reference/option/columns.searchPanes.show
      */
     public function show($value = true)
     {
         $this->attributes['show'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/columns.searchPanes.name
+     */
+    public function name($value)
+    {
+        $this->attributes['name'] = $value;
 
         return $this;
     }

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -3,6 +3,8 @@
 namespace Yajra\DataTables\Html;
 
 use Illuminate\Support\Fluent;
+use Illuminate\Contracts\Support\Arrayable;
+use Yajra\DataTables\Html\Editor\Fields\Options;
 
 class SearchPane extends Fluent
 {
@@ -67,6 +69,7 @@ class SearchPane extends Fluent
      * @param array $value
      * @return static
      * @see https://datatables.net/reference/option/searchPanes.dtOpts
+     * @see https://datatables.net/reference/option/columns.searchPanes.dtOpts
      */
     public function dtOpts(array $value = [])
     {
@@ -148,13 +151,21 @@ class SearchPane extends Fluent
     }
 
     /**
-     * @param mixed $value
+     * @param array $value
      * @return static
      * @see https://datatables.net/reference/option/searchPanes.panes
      */
-    public function panes($value)
+    public function panes(array $value)
     {
-        $this->attributes['panes'] = $value;
+        $panes = collect($value)->map(function ($pane) {
+            if ($pane instanceof Arrayable) {
+                return $pane->toArray();
+            }
+
+            return $pane;
+        })->toArray();
+
+        $this->attributes['panes'] = $panes;
 
         return $this;
     }
@@ -179,6 +190,90 @@ class SearchPane extends Fluent
     public function viewTotal($value = true)
     {
         $this->attributes['viewTotal'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get options from a model.
+     *
+     * @param mixed $model
+     * @param string $value
+     * @param string $key
+     * @return $this
+     */
+    public function modelOptions($model, $value, $key = 'id')
+    {
+        return $this->options(
+            Options::model($model, $value, $key)
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/columns.searchPanes.options
+     */
+    public function options($value)
+    {
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
+        }
+
+        $this->attributes['options'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get options from a table.
+     *
+     * @param mixed $table
+     * @param string $value
+     * @param string $key
+     * @param \Closure $whereCallback
+     * @param string|null $key
+     * @return $this
+     */
+    public function tableOptions($table, $value, $key = 'id', \Closure $whereCallback = null, $connection = null)
+    {
+        return $this->options(
+            Options::table($table, $value, $key, $whereCallback, $connection)
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/columns.searchPanes.className
+     */
+    public function className($value)
+    {
+        $this->attributes['className'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.panes.header
+     */
+    public function header($value)
+    {
+        $this->attributes['header'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/columns.searchPanes.show
+     */
+    public function show($value = true)
+    {
+        $this->attributes['show'] = $value;
 
         return $this;
     }

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use Illuminate\Support\Fluent;
+
+class SearchPane extends Fluent
+{
+    /**
+     * @param array $options
+     * @return static
+     */
+    public static function make(array $options = [])
+    {
+        return new static($options);
+    }
+
+    /**
+     * @param bool $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.cascadePanes
+     */
+    public function cascadePanes($value = true)
+    {
+        $this->attributes['cascadePanes'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.clear
+     */
+    public function clear($value = true)
+    {
+        $this->attributes['clear'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.columns
+     */
+    public function columns(array $value = [])
+    {
+        $this->attributes['columns'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.controls
+     */
+    public function controls($value = true)
+    {
+        $this->attributes['controls'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.dtOpts
+     */
+    public function dtOpts(array $value = [])
+    {
+        $this->attributes['dtOpts'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.emptyMessage
+     */
+    public function emptyMessage($value)
+    {
+        $this->attributes['emptyMessage'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.filterChanged
+     */
+    public function filterChanged($value)
+    {
+        $this->attributes['filterChanged'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.hideCount
+     */
+    public function hideCount($value = true)
+    {
+        $this->attributes['hideCount'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.layout
+     */
+    public function layout($value)
+    {
+        $this->attributes['layout'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.order
+     */
+    public function order($value)
+    {
+        $this->attributes['order'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param boolean $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.orderable
+     */
+    public function orderable($value = true)
+    {
+        $this->attributes['orderable'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @see https://datatables.net/reference/option/searchPanes.panes
+     */
+    public function panes($value)
+    {
+        $this->attributes['panes'] = $value;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-datatables/issues/2463
Fix https://github.com/yajra/laravel-datatables/issues/2471
Fix #130 

## USAGE

```php
// enable search panes
->searchPanes(true)

// enable search panes with array options
->searchPanes([
    'viewTotal' => true,
    'hideCount' => false,
])

// enable search pane with SearchPane builder class
->searchPanes(SearchPane::make()->cascadePanes(false)->hideCount())
```