### PR TITLE
Add function argument to override the default options from php scripts.

### DIFF
--- a/src/resources/views/function.blade.php
+++ b/src/resources/views/function.blade.php
@@ -1,5 +1,5 @@
 window.dtx = window.dtx || {};
-window.dtx["%1$s"] = function() {
+window.dtx["%1$s"] = function(opts) {
     window.LaravelDataTables = window.LaravelDataTables || {};
     @if(isset($editors))
     @foreach($editors as $editor)
@@ -10,5 +10,5 @@ window.dtx["%1$s"] = function() {
         @endforeach
     @endforeach
     @endif
-    return $("#%1$s").DataTable(%2$s);
+    return window.LaravelDataTables["%1$s"] = $("#%1$s").DataTable($.extend(%2$s, opts));
 }


### PR DESCRIPTION
Add LaravelDataTables table variable.

See https://github.com/yajra/laravel-datatables-html/pull/143 for initial usage.

## Example Code

```js
mounted() {
    let vm = this;
    this.documentsTable = window.dtx['documents-table']({
        stateSave: true,
        stateSaveParams(settings, data) {
            data.company_id = vm.companyId;
        },
        stateLoadParams(settings, data) {
            vm.companyId = data.company_id;
        }
    })
}
```