### PR TITLE
Add formatted column factory.

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -151,6 +151,23 @@ class Column extends Fluent
     }
 
     /**
+     * Make a new formatted column instance.
+     *
+     * @param string $name
+     * @return Column
+     */
+    public static function formatted($name)
+    {
+        $attr = [
+            'data'  => $name . '_formatted',
+            'name'  => $name,
+            'title' => self::titleFormat($name),
+        ];
+
+        return new static($attr);
+    }
+
+    /**
      * Create a checkbox column.
      *
      * @param string $title


### PR DESCRIPTION
To compliment https://github.com/yajra/laravel-datatables/pull/2193

```php
    public function dataTable($query)
    {
        return datatables()
            ->eloquent($query)
            ->formatColumn('created_at', DateFormatter::class)
            ->setRowId('id');
    }

    protected function getColumns()
    {
        return [
            Column::make('id'),
            Column::formatted('created_at'),
        ];
    }