### PR TITLE
Add method getTableId()

### DIFF
--- a/src/Html/HasTable.php
+++ b/src/Html/HasTable.php
@@ -44,6 +44,16 @@ trait HasTable
     }
 
     /**
+     * Get HTML table "id" attribute.
+     *
+     * @return string
+     */
+    public function getTableId()
+    {
+        return $this->getTableAttribute('id');
+    }
+
+    /**
      * Sets HTML table attribute(s).
      *
      * @param string|array $attribute


### PR DESCRIPTION
New method to simplify fetching of table id. 

## Before

```php
$datTable->getTableAttribute('id');
```

## After

```php
$dataTable->getTableId();
```