### PR TITLE
Add initEditor Event

### DIFF
--- a/src/Html/Editor/HasEvents.php
+++ b/src/Html/Editor/HasEvents.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
  * @method $this onEdit($script)
  * @method $this onInitCreate($script)
  * @method $this onInitEdit($script)
+ * @method $this onInitEditor($script)
  * @method $this onInitRemove($script)
  * @method $this onInitSubmit($script)
  * @method $this onOpen($script)


### PR DESCRIPTION
This will allow the IDE to suggest the initEditor method when chaining in HTML Editor. Fixed issue with php stan.
Available since Datatables Editor 1.9.1
Reference https://editor.datatables.net/reference/event/initEditor