### PR TITLE
Add onOpened Event

### DIFF
--- a/src/Html/Editor/HasEvents.php
+++ b/src/Html/Editor/HasEvents.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
  * @method $this onInitRemove($script)
  * @method $this onInitSubmit($script)
  * @method $this onOpen($script)
+ * @method $this onOpened($script)
  * @method $this onPostCreate($script)
  * @method $this onPostEdit($script)
  * @method $this onPostRemove($script)


### PR DESCRIPTION
This will allow the IDE to suggest the onOpened method when chaining in HTML Editor. 
Fixed issue with php stan.
Available since Datatables Editor 1.9.1
Reference https://editor.datatables.net/reference/event/opened
