### PR TITLE
Add onPreClose Event

### DIFF
--- a/src/Html/Editor/HasEvents.php
+++ b/src/Html/Editor/HasEvents.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Str;
  * @method $this onPostUpload($script)
  * @method $this onPreBlur($script)
  * @method $this onPreBlurCancelled($script)
+ * @method $this onPreClose($script)
  * @method $this onPreCreate($script)
  * @method $this onPreEdit($script)
  * @method $this onPreOpen($script)


### PR DESCRIPTION
This will allow the IDE to suggest the onPreClose method when chaining in HTML Editor. Fixed issue with php stan.
Available since Datatables Editor 1.0
Reference https://editor.datatables.net/reference/event/preClose