### PR TITLE
feat: add builder ability to use viteJs by default

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -74,11 +74,19 @@ class Builder
     }
 
     /**
-     * Set the default type to module or the DataTables javascript.
+     * Set the default type to module for the DataTables javascript.
      */
     public static function useVite(): void
     {
         static::$jsType = 'module';
+    }
+
+    /**
+     * Set the default type to text/javascript for the DataTables javascript.
+     */
+    public static function useWebpack(): void
+    {
+        static::$jsType = 'text/javascript';
     }
 
     /**

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -2,7 +2,6 @@
 
 namespace Yajra\DataTables\Html;
 
-use Yajra\DataTables\Html\HtmlBuilder;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Collection;
@@ -31,25 +30,26 @@ class Builder
     const SELECT_ITEMS_CELL = 'cell';
 
     /**
+     * The default type to use for the DataTables javascript.
+     */
+    protected static string $jsType = 'text/javascript';
+
+    /**
      * @var Collection<int, \Yajra\DataTables\Html\Column>
      */
     public Collection $collection;
-
     /**
      * @var array<string, string|null>
      */
     protected array $tableAttributes = [];
-
     /**
      * @var string
      */
     protected string $template = '';
-
     /**
      * @var array
      */
     protected array $attributes = [];
-
     /**
      * @var string|array
      */
@@ -74,6 +74,14 @@ class Builder
     }
 
     /**
+     * Set the default type to module or the DataTables javascript.
+     */
+    public static function useVite(): void
+    {
+        static::$jsType = 'module';
+    }
+
+    /**
      * Generate DataTable javascript.
      *
      * @param  string|null  $script
@@ -83,7 +91,9 @@ class Builder
     public function scripts(string $script = null, array $attributes = ['type' => 'text/javascript']): HtmlString
     {
         $script = $script ?: $this->generateScripts();
-        $attributes = $this->html->attributes($attributes);
+        $attributes = $this->html->attributes(
+            array_merge($attributes, ['type' => static::$jsType])
+        );
 
         return new HtmlString("<script{$attributes}>$script</script>");
     }

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -38,18 +38,22 @@ class Builder
      * @var Collection<int, \Yajra\DataTables\Html\Column>
      */
     public Collection $collection;
+
     /**
      * @var array<string, string|null>
      */
     protected array $tableAttributes = [];
+
     /**
      * @var string
      */
     protected string $template = '';
+
     /**
      * @var array
      */
     protected array $attributes = [];
+
     /**
      * @var string|array
      */

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -17,6 +17,8 @@ class BuilderTest extends TestCase
         Builder::useVite();
 
         $this->assertStringContainsString('type="module"', $this->getHtmlBuilder()->scripts()->toHtml());
+
+        Builder::useWebpack();
     }
 
     /** @test */

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -12,6 +12,14 @@ use Yajra\DataTables\Html\Editor\Editor;
 class BuilderTest extends TestCase
 {
     /** @test */
+    public function it_can_use_vitejs_module_script()
+    {
+        Builder::useVite();
+
+        $this->assertStringContainsString('type="module"', $this->getHtmlBuilder()->scripts()->toHtml());
+    }
+
+    /** @test */
     public function it_can_resolved_builder_class()
     {
         $builder = $this->getHtmlBuilder();


### PR DESCRIPTION
## Usage

Set the default javascript type to `module` by setting `Builder::useVite()` in the AppServiceProvider.

```php
namespace App\Providers;

use Illuminate\Pagination\Paginator;
use Illuminate\Support\ServiceProvider;
use Yajra\DataTables\Html\Builder;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        //
    }

    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
        Paginator::useBootstrapFive();
        Builder::useVite();
    }
}
```