### PR TITLE
fix: too long file name check for column render

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -512,7 +512,7 @@ class Column extends Fluent
             return $value($parameters);
         } elseif ($this->isBuiltInRenderFunction($value)) {
             return $value;
-        } elseif ($view->exists($value)) {
+        } elseif (strlen($value) < 256 && $view->exists($value)) {
             return $view->make($value)->with($parameters)->render();
         }
 


### PR DESCRIPTION
The Column::render method generates an error if the value within is too long because of path length limits of the OS.

Exception: *file_exists(): File name is longer than the maximum allowed path length on this platform (4096): /var/www/.../resources/views/{action content}*

I think 255 is a realistic length limit for view file names.