### PR TITLE
fix: Mixed Content problem with updating minifiedAjax method and get current url based on http or https scheme

### DIFF
--- a/src/Html/Options/HasAjax.php
+++ b/src/Html/Options/HasAjax.php
@@ -142,7 +142,7 @@ CDATA;
         $this->ajax = [];
         $appendData = $this->makeDataScript($data);
 
-        $this->ajax['url'] = empty($url) ? url()->full() : $url;
+        $this->ajax['url'] = empty($url) ? url()->current() : $url;
         $this->ajax['type'] = 'GET';
         if (! isset($this->attributes['serverSide']) || $this->attributes['serverSide']) {
             $this->ajax['data'] = 'function(data) {


### PR DESCRIPTION
Change `url()->full()` method to `url()->current()` to solve Mixed Content when using forceScheme('https') function in Laravel

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-html/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
