### PR TITLE
feat: add datetime field options

### DIFF
--- a/src/Html/Editor/Fields/DateTime.php
+++ b/src/Html/Editor/Fields/DateTime.php
@@ -137,7 +137,6 @@ class DateTime extends Field
      * @param  bool  $state
      * @return $this
      * @see https://editor.datatables.net/reference/field/datetime#Options
-     * @see https://momentjs.com/docs/#/displaying/format/
      */
     public function keyInput(bool $state = true): static
     {

--- a/src/Html/Editor/Fields/DateTime.php
+++ b/src/Html/Editor/Fields/DateTime.php
@@ -109,4 +109,59 @@ class DateTime extends Field
     {
         return $this->opts(['minutesAvailable' => $minutes]);
     }
+
+    /**
+     * The format of the date string loaded from the server for the field's
+     * value and also for sending to the server on form submission.
+     * The formatting options are defined by Moment.js.
+     *
+     * @param  string  $format
+     * @return $this
+     * @see https://editor.datatables.net/reference/field/datetime#Options
+     * @see https://momentjs.com/docs/#/displaying/format/
+     */
+    public function wireFormat(string $format = 'YYYY-MM-DDTHH:mm:ss.000000Z'): static
+    {
+        $this->attributes['wireFormat'] = $format;
+
+        return $this;
+    }
+
+    /**
+     * Allow (default), or disallow, the end user to type into the date / time input element.
+     * If disallowed, they must use the calendar picker to enter data. This can be useful
+     * if you are using a more complex date format and wish to disallow the user from
+     * potentially making typing mistakes, although note that it does also disallow
+     * pasting of data.
+     *
+     * @param  bool  $state
+     * @return $this
+     * @see https://editor.datatables.net/reference/field/datetime#Options
+     * @see https://momentjs.com/docs/#/displaying/format/
+     */
+    public function keyInput(bool $state = true): static
+    {
+        $this->attributes['keyInput'] = $state;
+
+        return $this;
+    }
+
+    /**
+     * The format of the date string that will be shown to the end user in the input element.
+     * The formatting options are defined by Moment.js. If a format is used that is not
+     * ISO8061 (i.e. YYYY-MM-DD) and Moment.js has not been included, Editor will
+     * throw an error stating that Moment.js must be included for custom
+     * formatting to be used.
+     *
+     * @param  string  $format
+     * @return $this
+     * @see https://editor.datatables.net/reference/field/datetime#Options
+     * @see https://momentjs.com/docs/#/displaying/format/
+     */
+    public function displayFormat(string $format = 'YYYY-MM-DD hh:mm a'): static
+    {
+        $this->attributes['displayFormat'] = $format;
+
+        return $this;
+    }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -107,6 +107,15 @@ class FieldTest extends TestCase
 
         $field->minutesAvailable([1, 2]);
         $this->assertEquals([1, 2], $field->opts['minutesAvailable']);
+
+        $field->keyInput(false);
+        $this->assertEquals(false, $field->getAttributes()['keyInput']);
+
+        $field->displayFormat('LLL');
+        $this->assertEquals('LLL', $field->getAttributes()['displayFormat']);
+
+        $field->wireFormat('LLL');
+        $this->assertEquals('LLL', $field->getAttributes()['wireFormat']);
     }
 
     /** @test */


### PR DESCRIPTION
Add missing datetime options as per https://editor.datatables.net/reference/field/datetime#Options.