### PR TITLE
feat: hide/show fields based on editor action

### DIFF
--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -293,18 +293,18 @@ class Editor extends Fluent
      */
     public function hiddenOn(string $action, array $fields): static
     {
-        $script = 'function(e, mode, action) {'.PHP_EOL;
-        $script .= "if (action === '{$action}') {".PHP_EOL;
+        $script = 'function(e, mode, action) {';
+        $script .= "if (action === '{$action}') {";
         foreach ($fields as $field) {
-            $script .= "this.hide('{$field}');".PHP_EOL;
+            $script .= "this.hide('{$field}');";
         }
-        $script .= '} else {'.PHP_EOL;
+        $script .= '} else {';
         foreach ($fields as $field) {
-            $script .= "this.show('{$field}');".PHP_EOL;
+            $script .= "this.show('{$field}');";
         }
-        $script .= '}'.PHP_EOL;
-        $script .= 'return true;'.PHP_EOL;
-        $script .= '}'.PHP_EOL;
+        $script .= '}';
+        $script .= 'return true;';
+        $script .= '}';
 
         $this->onPreOpen($script);
 

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -24,13 +24,13 @@ class Editor extends Fluent
     use HasEvents;
     use HasAuthorizations;
 
-    public array $events = [];
-
     const DISPLAY_LIGHTBOX = 'lightbox';
     const DISPLAY_ENVELOPE = 'envelope';
     const DISPLAY_BOOTSTRAP = 'bootstrap';
     const DISPLAY_FOUNDATION = 'foundation';
     const DISPLAY_JQUERYUI = 'jqueryui';
+
+    public array $events = [];
 
     /**
      * Editor constructor.
@@ -156,6 +156,18 @@ class Editor extends Fluent
     }
 
     /**
+     * Set Editor's bubble formOptions.
+     *
+     * @param  array  $formOptions
+     * @return $this
+     * @see https://editor.datatables.net/reference/option/formOptions.bubble
+     */
+    public function formOptionsBubble(array $formOptions): static
+    {
+        return $this->formOptions(['bubble' => Helper::castToArray($formOptions)]);
+    }
+
+    /**
      * Set Editor's formOptions.
      *
      * @param  array  $formOptions
@@ -168,18 +180,6 @@ class Editor extends Fluent
         $this->attributes['formOptions'] = $formOptions;
 
         return $this;
-    }
-
-    /**
-     * Set Editor's bubble formOptions.
-     *
-     * @param  array  $formOptions
-     * @return $this
-     * @see https://editor.datatables.net/reference/option/formOptions.bubble
-     */
-    public function formOptionsBubble(array $formOptions): static
-    {
-        return $this->formOptions(['bubble' => Helper::castToArray($formOptions)]);
     }
 
     /**
@@ -271,5 +271,65 @@ class Editor extends Fluent
         unset($parameters['events']);
 
         return Helper::toJsonScript($parameters, $options);
+    }
+
+    /**
+     * Hide fields on create action.
+     *
+     * @param  array  $fields
+     * @return $this
+     */
+    public function hiddenOnCreate(array $fields): static
+    {
+        return $this->hiddenOn('create', $fields);
+    }
+
+    /**
+     * Hide fields on specific action.
+     *
+     * @param  string  $action
+     * @param  array  $fields
+     * @return $this
+     */
+    public function hiddenOn(string $action, array $fields): static
+    {
+        $script = 'function(e, mode, action) {'.PHP_EOL;
+        $script .= "if (action === '{$action}') {".PHP_EOL;
+        foreach ($fields as $field) {
+            $script .= "this.hide('{$field}');".PHP_EOL;
+        }
+        $script .= '} else {'.PHP_EOL;
+        foreach ($fields as $field) {
+            $script .= "this.show('{$field}');".PHP_EOL;
+        }
+        $script .= '}'.PHP_EOL;
+        $script .= 'return true;'.PHP_EOL;
+        $script .= '}'.PHP_EOL;
+
+        $this->onPreOpen($script);
+
+        return $this;
+    }
+
+    /**
+     * Hide fields on edit action.
+     *
+     * @param  array  $fields
+     * @return $this
+     */
+    public function hiddenOnEdit(array $fields): static
+    {
+        return $this->hiddenOn('edit', $fields);
+    }
+
+    /**
+     * Hide fields on remove action.
+     *
+     * @param  array  $fields
+     * @return $this
+     */
+    public function hiddenOnRemove(array $fields): static
+    {
+        return $this->hiddenOn('remove', $fields);
     }
 }

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -294,13 +294,13 @@ class Editor extends Fluent
     public function hiddenOn(string $action, array $fields): static
     {
         $script = 'function(e, mode, action) {';
-        $script .= "if (action === '{$action}') {";
+        $script .= "if (action === '$action') {";
         foreach ($fields as $field) {
-            $script .= "this.hide('{$field}');";
+            $script .= "this.hide('$field');";
         }
         $script .= '} else {';
         foreach ($fields as $field) {
-            $script .= "this.show('{$field}');";
+            $script .= "this.show('$field');";
         }
         $script .= '}';
         $script .= 'return true;';

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -321,15 +321,4 @@ class Editor extends Fluent
     {
         return $this->hiddenOn('edit', $fields);
     }
-
-    /**
-     * Hide fields on remove action.
-     *
-     * @param  array  $fields
-     * @return $this
-     */
-    public function hiddenOnRemove(array $fields): static
-    {
-        return $this->hiddenOn('remove', $fields);
-    }
 }

--- a/tests/EditorTest.php
+++ b/tests/EditorTest.php
@@ -60,6 +60,25 @@ class EditorTest extends TestCase
     }
 
     /** @test */
+    public function it_can_show_hide_fields()
+    {
+        $editor = $this->getEditor();
+
+        $editor->hiddenOnCreate(['name']);
+        $editor->hiddenOnEdit(['email']);
+
+        $this->assertCount(2, $editor->events);
+
+        $this->assertEquals('preOpen', $editor->events[0]['event']);
+        $this->assertStringContainsString("action === 'create'", $editor->events[0]['script']);
+        $this->assertStringContainsString("this.hide('name')", $editor->events[0]['script']);
+
+        $this->assertEquals('preOpen', $editor->events[1]['event']);
+        $this->assertStringContainsString("action === 'edit'", $editor->events[1]['script']);
+        $this->assertStringContainsString("this.hide('email')", $editor->events[1]['script']);
+    }
+
+    /** @test */
     public function it_has_authorizations()
     {
         $editor = Editor::makeIf(true, 'editor')


### PR DESCRIPTION
## Usage

```php
Editor::make()
      ->hiddenOnCreate(['is_blocked'])
      ->hiddenOnEdit(['password', 'password_confirmation'])
      ->fields([
          Fields\Text::make('name'),
          Fields\Text::make('email'),
          Fields\Select::make('is_blocked')->options([
              0 => 'No',
              1 => 'Yes',
          ]),
          Fields\Password::make('password'),
          Fields\Password::make('password_confirmation'),
      ]),
```