### PR TITLE
The attributes parameter is never used.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -104,7 +104,7 @@ class Builder
     {
         $script = $script ?: $this->generateScripts();
         $attributes = $this->html->attributes(
-            array_merge($attributes, ['type' => static::$jsType])
+            array_merge($attributes, ['type' => $attributes['type'] ?? static::$jsType])
         );
 
         return new HtmlString("<script{$attributes}>$script</script>");


### PR DESCRIPTION
I was following the Quick Starter and it always gave me the jquery(`ReferenceError: $ is not defined`) error.

when we used this code( `{{ $dataTable->scripts(attributes: ['type' => 'module']) }}` ) , the type was always `type="text/javascript"` not `'module'` as expected.