### PR TITLE
feat: add exportRender method to be used in datatable-buttons for render pr…

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -494,7 +494,7 @@ class Column extends Fluent
     /**
      * Set Callback function to render column for Print + Export
      *
-     * @param  function  $callback
+     * @param  callable  $callback
      * @return $this
 
      */

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -492,6 +492,20 @@ class Column extends Fluent
     }
 
     /**
+     * Set Callback function to render column for Print + Export
+     *
+     * @param  function  $callback
+     * @return $this
+
+     */
+    public function exportRender(callable $callback): static
+    {
+        $this->attributes['exportRender'] = $callback;
+
+        return $this;
+    }
+
+    /**
      * Parse render attribute.
      *
      * @param  mixed  $value


### PR DESCRIPTION
this commit is about development not bug fix:

i realize a need to render column data for export, i found it by adding Export Class to set how to render export
but i couldn't find any thing for render print
and i need a centralized render for print & export (for simplicity & integrity)
so i added exportRender method to be used for pass a callback function to determine how targeted column data should be rendered for print & export, sample code is shown below:
Column::make('used')->title('Use Status')->exportRender(function($row,$data){return $data == 1 ? 'Yes' : 'Not Yet'});

but in this commit just method added and it should be paired to commit 56b94a4482f4273ce57b08b5cd05dbc695dfce22 in laravel-datatable-buttons repo to be pushed for calling callback function which is set in exportRender for rendering column data

please accept that pull request too after this pull request