### PR TITLE
fix: show searchPanes by default

### DIFF
--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -10,6 +10,11 @@ use Yajra\DataTables\Html\Editor\Fields\Options;
 
 class SearchPane extends Fluent
 {
+    public function __construct($attributes = [])
+    {
+        parent::__construct(['show' => true] + $attributes);
+    }
+
     /**
      * @param  array  $options
      * @return static


### PR DESCRIPTION
fix: https://github.com/yajra/laravel-datatables-docs/pull/74#issuecomment-1645043870
fix: https://github.com/yajra/laravel-datatables/pull/2475#issuecomment-1645043408

## Usage

### Using via `searchPanes` option

```php
  ->dom('PBfrtip')
  ->searchPanes(SearchPane::make())
```

### Using via `searchPanes` button

```php
  ->addColumnDef([
    'targets' => '_all',
    'searchPanes' => SearchPane::make()
  ])
  ->buttons([Button::make('searchPanes')])
```