### PR TITLE
fix: add missing Arrayable param

### DIFF
--- a/src/Html/Options/Plugins/SearchPanes.php
+++ b/src/Html/Options/Plugins/SearchPanes.php
@@ -16,7 +16,7 @@ trait SearchPanes
     /**
      * Set searchPane option value.
      *
-     * @param  array|bool|callable  $value
+     * @param  array|Arrayable|bool|callable  $value
      * @return $this
      * @see https://datatables.net/reference/option/searchPanes
      */


### PR DESCRIPTION
fix phpstan error:

```
Parameter #1 $value of method Yajra\DataTables\Html\Builder::searchPanes() expects array|bool|(callable(): mixed), Yajra\DataTables\Html\SearchPane given.
```