### PR TITLE
feat: Add optional scout js script

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -60,6 +60,11 @@ class Builder
     protected string|array $ajax = '';
 
     /**
+     * @var array
+     */
+    protected array $additionalScripts = [];
+
+    /**
      * @param  Repository  $config
      * @param  Factory  $view
      * @param  HtmlBuilder  $html
@@ -179,7 +184,7 @@ class Builder
 
         $template = $this->template ?: $configTemplate;
 
-        return $this->view->make($template, ['editors' => $this->editors])->render();
+        return $this->view->make($template, ['editors' => $this->editors, 'scripts' => $this->additionalScripts])->render();
     }
 
     /**
@@ -290,5 +295,18 @@ class Builder
         }
 
         return $this->ajax;
+    }
+
+    /**
+     * Add additional scripts to the DataTables JS initialization.
+     *
+     * @param  string  $view
+     * @return $this
+     */
+    public function addScript(string $view): static
+    {
+        $this->additionalScripts[] = $view;
+
+        return $this;
     }
 }

--- a/src/resources/views/scout.blade.php
+++ b/src/resources/views/scout.blade.php
@@ -1,0 +1,23 @@
+$(function(){
+    $('#%1$s').on('xhr.dt', function (e, settings, json, xhr) {
+        if (json == null || !('disableOrdering' in json)) return;
+
+        let table = LaravelDataTables[$(this).attr('id')];
+        if (json.disableOrdering) {
+            table.settings()[0].aoColumns.forEach(function(column) {
+                column.bSortable = false;
+                $(column.nTh).removeClass('sorting_asc sorting_desc sorting').addClass('sorting_disabled');
+            });
+        } else {
+            let changed = false;
+            table.settings()[0].aoColumns.forEach(function(column) {
+                if (column.bSortable) return;
+                column.bSortable = true;
+                changed = true;
+            });
+            if (changed) {
+                table.draw();
+            }
+        }
+    });
+});

--- a/src/resources/views/scout.blade.php
+++ b/src/resources/views/scout.blade.php
@@ -2,7 +2,7 @@ $(function(){
     $('#%1$s').on('xhr.dt', function (e, settings, json, xhr) {
         if (json == null || !('disableOrdering' in json)) return;
 
-        let table = LaravelDataTables[$(this).attr('id')];
+        let table = {{ config('datatables-html.namespace', 'LaravelDataTables') }}[$(this).attr('id')];
         if (json.disableOrdering) {
             table.settings()[0].aoColumns.forEach(function(column) {
                 column.bSortable = false;

--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,1 +1,4 @@
 $(function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});
+@foreach ($scripts as $script)
+@include($script)
+@endforeach


### PR DESCRIPTION
See yajra/laravel-datatables#3082

Added general system to include additional js scripts to the initialization and added specific (optional) scout addition for abovementioned pull request.

Usage:
```php
public function html(): HtmlBuilder
{
	return $this->builder()
		->setTableId('products-table')
		->addScript('datatables::scout');
}
```