### PR TITLE
feat: add batch remove optimization script (optional)

### DIFF
--- a/src/resources/views/functions/batch_remove.blade.php
+++ b/src/resources/views/functions/batch_remove.blade.php
@@ -1,0 +1,14 @@
+$(function(){
+    @foreach($editors as $editor)
+        {{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s-{{$editor->instance}}"].on('preSubmit', function(e, data, action) {
+            if (action !== 'remove') return;
+
+            for (let row_id of Object.keys(data.data))
+            {
+                data.data[row_id] = {
+                    DT_RowId: data.data[row_id].DT_RowId
+                };
+            }
+        });
+    @endforeach
+});


### PR DESCRIPTION
Now that there is a feature for additional scripts, here is a script I have been using for a long time.

Problem: When batch removing many rows via Editor, and the rows contain large amounts of data, the remove requests become slow and sometimes even fail due to server limits.

That's because Datatables adds all the column data to the remove request, which is unnecessary in most of the cases. This script modifies the data before it's sent to the server and removes all data from it except the DT_RowId, which is enough for the removal. This results in a more stable and efficient batch removal.

Usage:
```php
/**
 * Optional method if you want to use the html builder.
 */
public function html(): HtmlBuilder
{
	return $this->builder()
		[...]
		->addScript('datatables::functions.batch_remove');
}
```