### PR TITLE
fix: multiple config option of select2

### DIFF
--- a/src/Html/Editor/Fields/Select2.php
+++ b/src/Html/Editor/Fields/Select2.php
@@ -38,6 +38,11 @@ class Select2 extends Select
         ]);
     }
 
+    public function multiple(bool $value = true): static
+    {
+        return $this->opts(['multiple' => $value]);
+    }
+
     /**
      * Set select2 ajax option.
      *


### PR DESCRIPTION
This pull request aims to fix the multiple configuration option of select2.

The multiple() of Select2 field method does not work as intended because it uses the multiple method of its inherited class Yajra\DataTables\Html\Editor\Fields\Select.

Though it can be defined via opts() method as a workaround, I think it we should override the multiple() method to properly assign it to field opts value.

Thanks!