### PR TITLE
feat: add className method to Editor Field

### DIFF
--- a/src/Html/Editor/Fields/Field.php
+++ b/src/Html/Editor/Fields/Field.php
@@ -375,7 +375,7 @@ class Field extends Fluent
 
         return $this;
     }
-    
+
     /**
      * @return $this
      *

--- a/src/Html/Editor/Fields/Field.php
+++ b/src/Html/Editor/Fields/Field.php
@@ -375,4 +375,16 @@ class Field extends Fluent
 
         return $this;
     }
+    
+    /**
+     * @return $this
+     *
+     * @see https://editor.datatables.net/reference/option/fields.className
+     */
+    public function className(string $className): static
+    {
+        $this->attributes['className'] = $className;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
I had always used `->className()` on my Editor Fields without any problems, but strangely with v11.x it doesn't work anymore. Looked into the code and saw that the method never existed - so here we go!

Any idea why it worked before v11.x? Did Laravel change something on their `Fluent` class in v11?