### PR TITLE
Ability to use static data (no server-side)

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -47,6 +47,11 @@ class Builder
     public Collection $collection;
 
     /**
+     * @var Collection<int, array>
+     */
+    public Collection $rows;
+
+    /**
      * @var array<string, string|null>
      */
     protected array $tableAttributes = [];
@@ -68,6 +73,7 @@ class Builder
         $defaults = $this->config->get('datatables-html.table', []);
 
         $this->collection = new Collection;
+        $this->rows = new Collection;
         $this->tableAttributes = $defaults;
     }
 
@@ -178,6 +184,18 @@ class Builder
 
         $tableHtml .= '<thead'.($this->theadClass ?? '').'>';
         $tableHtml .= '<tr>'.implode('', $th).'</tr>'.$searchHtml.'</thead>';
+
+        if ($this->attributes['serverSide'] === false) {
+            $tableHtml .= '<tbody>';
+            foreach ($this->getRows() as $row) {
+                $tableHtml .= '<tr>';
+                foreach ($this->getColumns() as $column) {
+                    $tableHtml .= '<td>'.$row->getCellContentForColumn($column).'</td>';
+                }
+                $tableHtml .= '</tr>';
+            }
+            $tableHtml .= '</tbody>';
+        }
 
         if ($drawFooter) {
             $tf = $this->compileTableFooter();

--- a/src/Html/Cell.php
+++ b/src/Html/Cell.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use Illuminate\Support\Fluent;
+
+/**
+ * @property string $column
+ * @property string $content
+ */
+class Cell extends Fluent
+{
+    /**
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $attributes['attributes'] ??= [];
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Make a new column instance.
+     */
+    public static function make(array|string $data = [], string $content = ''): static
+    {
+        $attributes = $data;
+
+        if (is_string($data)) {
+            $attributes = [
+                'column' => $data,
+                'content' => $content,
+            ];
+        }
+
+        return new static($attributes);
+    }
+
+    /**
+     * @return $this
+     */
+    public function column(string $value): static
+    {
+        $this->attributes['column'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function content(string $value): static
+    {
+        $this->attributes['content'] = $value;
+
+        return $this;
+    }
+}

--- a/src/Html/HasOptions.php
+++ b/src/Html/HasOptions.php
@@ -12,6 +12,7 @@ trait HasOptions
     use Options\HasAjax;
     use Options\HasCallbacks;
     use Options\HasColumns;
+    use Options\HasRows;
     use Options\HasFeatures;
     use Options\HasInternationalisation;
     use Options\Plugins\AutoFill;

--- a/src/Html/Options/HasRows.php
+++ b/src/Html/Options/HasRows.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yajra\DataTables\Html\Options;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use Yajra\DataTables\Html\Row;
+
+/**
+ * DataTables - Row option builder.
+ */
+trait HasRows
+{
+    /**
+     * Set columns option value.
+     *
+     * @return $this
+     *
+     * @see https://datatables.net/reference/option/columns
+     */
+    public function rows(array $rows): static
+    {
+        $this->rows = new Collection;
+
+        foreach ($rows as $key => $value) {
+            if (! is_a($value, Row::class)) {
+                if (array_key_exists('cells', $value)) {
+                    $cells = $value['cells'];
+                    $attributes = $value['attributes'] ?? [];
+                } else {
+                    $cells = $value;
+                    $attributes = [];
+                }
+
+                $this->rows->push(new Row($attributes, $cells));
+            } else {
+                $this->rows->push($value);
+            }
+        }
+
+        return $this;
+    }
+
+    public function setRows(Collection|array $rows): static
+    {
+        $this->rows = collect($rows);
+
+        return $this;
+    }
+
+    /**
+     * Get collection of rows.
+     *
+     * @return \Illuminate\Support\Collection<array-key, array>
+     */
+    public function getRows(): Collection
+    {
+        return $this->rows;
+    }
+}

--- a/src/Html/Row.php
+++ b/src/Html/Row.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Collection;
+
+/**
+ * @property string $content
+ * @method content($content)
+ */
+class Row extends Fluent
+{
+    public function __construct(array $attributes = [], array $cells = [])
+    {
+        $attributes['attributes'] ??= [];
+
+        $this->buildCells($cells);
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Make a new column instance.
+     */
+    public static function make(array $attributes = [], array $cells = []): static
+    {
+        return new static($attributes, $cells);
+    }
+
+    public function cells($cells): static
+    {
+        $this->cells = collect($cells);
+
+        return $this;
+    }
+
+    protected function buildCells(array $cells): static
+    {
+        $this->cells = new Collection;
+
+        foreach ($cells as $key => $value) {
+            if (! is_a($value, Cell::class)) {
+                if (is_array($value)) {
+                    $cellAttributes = array_merge($value, [
+                        'column' => $value['column'] ?? $key,
+                        'content' => $value['content'] ?? null,
+                    ]);
+                } else {
+                    $cellAttributes = [
+                        'column' => $key,
+                        'content' => $value,
+                    ];
+                }
+
+                $this->cells->push(new Cell($cellAttributes));
+            } else {
+                $this->cells->push($value);
+            }
+        }
+
+        $this->cells = $this->cells->keyBy('column');
+
+        return $this;
+    }
+
+    public function getCellContentForColumn(Column $column): mixed
+    {
+        if ($this->cells->has($column->data)) {
+            return $this->cells->get($column->data)->content;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
I recently wanted to use the package for a "array based datatable".

Sadly when I do;

```blade
{!! $dataTable->table() !!}
```

it doesn't generate the tables body.

I added some logic to the `Builder` class so that we can make it fill the `tbody` IF the `serverSide` option is disabled.

Here is an example DataTable I've prepared along with 2 methods `makingRowExample` and `makingCellExample` explaining how the `Row` and `Cell` classes apis work. I tried to make things similar to the `Column` class which we already.

There area a couple important places I've marked via comments inside the code.

```php
<?php

namespace App\DataTables;

use App\DataTables\Core\Html\Column;
use App\Models\User;
use Yajra\DataTables\Html\Builder;
use Yajra\DataTables\Html\Cell;
use Yajra\DataTables\Html\Row;
use Yajra\DataTables\Services\DataTable;

class ExampleStaticDataTable extends DataTable
{
    // IMPORTANT: 
    // You can name this method whatever you want, it will simply allow you to populate the rows data
    public function buildRows()
    {
        $users = User::query()->get();

        $rows = [];

        /** @var User $user */
        foreach ($users as $doctorId => $user) {
            $rows[] = [
                'full_name' => $user->full_name,
                'email' => $user->email,
                'created_at' => $user->created_at?->format('Y-m-d H:i:s') ?? 'N/A',
            ];
        }

        return $rows;
    }

    // IMPORTANT: 
    // Here we call the `rows(array $rows = [])` method on the `Builder` instance
    // set the `serverSide` attribute to `false`
    public function html(): Builder
    {
        return $this
            ->builder()
            ->rows($this->buildRows())
            ->serverSide(false);
    }

    public function getColumns(): array
    {
        return [
            Column::make('full_name'),
            Column::make('email'),
            Column::make('created_at'),
        ];
    }

    // IMPORTANT: 
    // Example usages of the Row api
    public function makingRowExample()
    {
        // Option 1:
        //      If your row doesn't have any attributes,
        //      you can directly use array for its cells.
        $rowExample1 = [
            // Cells here...
        ];

        // Option 2:
        //      If your row has attributes,
        //      you must put the cells to the `cells` key.
        $rowExample2 = [
            'row-class' => 'gray-row',
            'cells' => [
                // Cells here...
            ],
        ];

        // Option 3:
        //      If your row has no attributes,
        //      leave the first parameter as an empty array.
        $rowExample3 = Row::make([
            'row-class' => 'gray-row',
        ], [
            // Cells here...
        ]);
        $rowExample4 = Row::make([
            'row-class' => 'gray-row',
        ])->cells([
            // Cells here...
        ]);
    }

    // IMPORTANT: 
    // Example usages of the Cell api
    public function makingCellExample()
    {
        // Option 1 - Directly inside Row array as `key => value` pairs
        $cellExample1_1 = [
            'column_1' => 'Column #1 Content',
            'column_2' => 'Column #2 Content',
        ];
        $cellExample1_2 = [
            'cells' => [
                'column_1' => 'Column #1 Content',
                'column_2' => 'Column #2 Content',
            ],
        ];

        // Option 2 - Using array
        $cellExample2 = [
            'column' => 'column_1',
            'content' => 'Column #1 Content',
        ];

        // Option 3 - Using Cell Object
        $cellExample3_1 = Cell::make('column_1', 'Column #1 Content');
        $cellExample3_2 = Cell::make('column_1')->content('Column #1 Content');
    }
}
