### PR TITLE
Fix unauthorized columns being displayed by builder

### DIFF
--- a/src/Html/Options/HasColumns.php
+++ b/src/Html/Options/HasColumns.php
@@ -92,7 +92,11 @@ trait HasColumns
 
                 $this->collection->push(new Column($attributes));
             } else {
-                $this->collection->push($value);
+
+                // Only add the column if it is authorized, otherwise ignore it.
+                if ($value->isAuthorized()) {
+                    $this->collection->push($value);
+                }
             }
         }
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -287,4 +287,19 @@ class BuilderTest extends TestCase
         ]);
         $this->assertCount(2, $builder->getEditors());
     }
+
+    #[Test]
+    public function it_ignores_unauthorized_columns(): void
+    {
+        $builder = $this->getHtmlBuilder();
+
+        $builder->columns([
+            Column::makeIf(false)
+                ->title('unauthorized_column'),
+
+            Column::make('authorized_column'),
+        ]);
+
+        $this->assertCount(1, $builder->getColumns());
+    }
 }


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-html/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

Hey Yajra hope you're doing well!


Here is the fix for the unauthorized columns being displayed in the HTML builder. I decided to simply ignore all unauthorized columns when adding columns in the HasColumns trait, that way they are completely absent from the column's collection.


Closes #222 

