### PR TITLE
feat: add macro in editor builder

### DIFF
--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -4,6 +4,8 @@ namespace Yajra\DataTables\Html\Editor;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Yajra\DataTables\Html\Editor\Fields\Field;
 use Yajra\DataTables\Html\HasAuthorizations;
 use Yajra\DataTables\Utilities\Helper;
@@ -22,7 +24,9 @@ use Yajra\DataTables\Utilities\Helper;
 class Editor extends Fluent
 {
     use HasAuthorizations;
-    use HasEvents;
+    use HasEvents, Macroable {
+        Macroable::__call as macroCall;
+    }
 
     final public const DISPLAY_LIGHTBOX = 'lightbox';
 
@@ -313,5 +317,16 @@ class Editor extends Fluent
     public function hiddenOnEdit(array $fields): static
     {
         return $this->hiddenOn('edit', $fields);
+    }
+
+    public function __call($method, $parameters): mixed
+    {
+        if (Str::startsWith($method, 'on')) {
+            $event = Str::camel(substr($method, 2, strlen($method) - 2));
+
+            return $this->on($event, $parameters[0]);
+        }
+
+        return $this->macroCall($method, $parameters);
     }
 }

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -327,6 +327,12 @@ class Editor extends Fluent
             return $this->on($event, $parameters[0]);
         }
 
-        return $this->macroCall($method, $parameters);
+        $macroCall = $this->macroCall($method, $parameters);
+
+        if (! $macroCall instanceof Editor) {
+            abort(500, sprintf('Method %s::%s must return an Editor instance.', static::class, $method));
+        }
+
+        return $this;
     }
 }

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -319,7 +319,7 @@ class Editor extends Fluent
         return $this->hiddenOn('edit', $fields);
     }
 
-    public function __call($method, $parameters): mixed
+    public function __call($method, $parameters): static
     {
         if (Str::startsWith($method, 'on')) {
             $event = Str::camel(substr($method, 2, strlen($method) - 2));


### PR DESCRIPTION
## Usage

```php
        Editor::macro('focusOnOpen', function (string $field) {
            /** @var Editor $this */
            $this->onOpen("function() { $('#DTE_Field_{$field}').focus(); }");

            return $this;
        });

        Editor::macro('submitOnReturn', function (string|bool $action = 'submit') {
            /** @var Editor $this */
            $this->formOptionsMain(['onReturn' => $action]);

            return $this;
        });
```

## Use Case

```php
                Editor::make()
                    ->ajax(route('accounts.store', $this->account))
                    ->submitOnReturn(false)
                    ->focusOnOpen('amount')
```