### PR TITLE
feat: clone the "working" `Fluent` class from laravel

### DIFF
--- a/src/Html/Button.php
+++ b/src/Html/Button.php
@@ -4,7 +4,6 @@ namespace Yajra\DataTables\Html;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 
 class Button extends Fluent implements Arrayable

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -3,7 +3,6 @@
 namespace Yajra\DataTables\Html;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Yajra\DataTables\Html\Options\Plugins\SearchPanes;
 

--- a/src/Html/Editor/Editor.php
+++ b/src/Html/Editor/Editor.php
@@ -3,10 +3,10 @@
 namespace Yajra\DataTables\Html\Editor;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Yajra\DataTables\Html\Editor\Fields\Field;
+use Yajra\DataTables\Html\Fluent;
 use Yajra\DataTables\Html\HasAuthorizations;
 use Yajra\DataTables\Utilities\Helper;
 

--- a/src/Html/Editor/Fields/Field.php
+++ b/src/Html/Editor/Fields/Field.php
@@ -6,9 +6,9 @@ use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Yajra\DataTables\Html\Fluent;
 use Yajra\DataTables\Html\HasAuthorizations;
 
 /**

--- a/src/Html/Editor/FormOptions.php
+++ b/src/Html/Editor/FormOptions.php
@@ -2,7 +2,7 @@
 
 namespace Yajra\DataTables\Html\Editor;
 
-use Illuminate\Support\Fluent;
+use Yajra\DataTables\Html\Fluent;
 
 /**
  * @see https://editor.datatables.net/reference/type/form-options

--- a/src/Html/Fluent.php
+++ b/src/Html/Fluent.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Yajra\DataTables\Html;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @implements \ArrayAccess<TKey, TValue>
+ */
+class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
+{
+    /**
+     * All of the attributes set on the fluent instance.
+     *
+     * @var array<TKey, TValue>
+     */
+    protected $attributes = [];
+
+    /**
+     * Create a new fluent instance.
+     *
+     * @param  iterable<TKey, TValue>  $attributes
+     * @return void
+     */
+    public function __construct($attributes = [])
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $value;
+        }
+    }
+
+    /**
+     * Get an attribute from the fluent instance using "dot" notation.
+     *
+     * @template TGetDefault
+     *
+     * @param  TKey  $key
+     * @param  TGetDefault|(\Closure(): TGetDefault)  $default
+     * @return TValue|TGetDefault
+     */
+    public function get($key, $default = null)
+    {
+        return data_get($this->attributes, $key, $default);
+    }
+
+    /**
+     * Get an attribute from the fluent instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function value($key, $default = null)
+    {
+        if (array_key_exists($key, $this->attributes)) {
+            return $this->attributes[$key];
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Get the value of the given key as a new Fluent instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return static
+     */
+    public function scope($key, $default = null)
+    {
+        return new static(
+            (array) $this->get($key, $default)
+        );
+    }
+
+    /**
+     * Get the attributes from the fluent instance.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Convert the fluent instance to an array.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function toArray()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Convert the fluent instance to a Collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return new Collection($this->get($key));
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the fluent instance to JSON.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Determine if the given offset exists.
+     *
+     * @param  TKey  $offset
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    /**
+     * Get the value for a given offset.
+     *
+     * @param  TKey  $offset
+     * @return TValue|null
+     */
+    public function offsetGet($offset): mixed
+    {
+        return $this->value($offset);
+    }
+
+    /**
+     * Set the value at the given offset.
+     *
+     * @param  TKey  $offset
+     * @param  TValue  $value
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->attributes[$offset] = $value;
+    }
+
+    /**
+     * Unset the value at the given offset.
+     *
+     * @param  TKey  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->attributes[$offset]);
+    }
+
+    /**
+     * Handle dynamic calls to the fluent instance to set attributes.
+     *
+     * @param  TKey  $method
+     * @param  array{0: ?TValue}  $parameters
+     * @return $this
+     */
+    public function __call($method, $parameters)
+    {
+        $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically retrieve the value of an attribute.
+     *
+     * @param  TKey  $key
+     * @return TValue|null
+     */
+    public function __get($key)
+    {
+        return $this->value($key);
+    }
+
+    /**
+     * Dynamically set the value of an attribute.
+     *
+     * @param  TKey  $key
+     * @param  TValue  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->offsetSet($key, $value);
+    }
+
+    /**
+     * Dynamically check if an attribute is set.
+     *
+     * @param  TKey  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+    /**
+     * Dynamically unset an attribute.
+     *
+     * @param  TKey  $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        $this->offsetUnset($key);
+    }
+}

--- a/src/Html/Layout.php
+++ b/src/Html/Layout.php
@@ -6,7 +6,6 @@ namespace Yajra\DataTables\Html;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\View\Component;
 use InvalidArgumentException;

--- a/src/Html/Parameters.php
+++ b/src/Html/Parameters.php
@@ -2,8 +2,6 @@
 
 namespace Yajra\DataTables\Html;
 
-use Illuminate\Support\Fluent;
-
 class Parameters extends Fluent
 {
     /**

--- a/src/Html/SearchPane.php
+++ b/src/Html/SearchPane.php
@@ -5,7 +5,6 @@ namespace Yajra\DataTables\Html;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Support\Fluent;
 use Yajra\DataTables\Html\Editor\Fields\Options;
 
 class SearchPane extends Fluent


### PR DESCRIPTION
Fixes #229
Closes https://github.com/yajra/laravel-datatables/issues/3201

Copy Laravel's "working" `Fluent` class into this code base.
