### PR TITLE
feat: add tags field support

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,8 @@ parameters:
 
     ignoreErrors:
         - '#Unsafe usage of new static\(\).#'
+        - identifier: missingType.generics
+        - identifier: missingType.iterableValue
 
     excludePaths:
-
-    checkMissingIterableValueType: false
-
-    checkGenericClassInNonGenericObjectType: false
+        - ./src/Html/Fluent.php

--- a/src/Html/Editor/Fields/Tags.php
+++ b/src/Html/Editor/Fields/Tags.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Yajra\DataTables\Html\Editor\Fields;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @see https://editor.datatables.net/reference/field/tags
+ */
+class Tags extends Field
+{
+    protected string $type = 'tags';
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#ajax
+     */
+    public function ajax(bool|string|null $url = true): static
+    {
+        $this->attributes['ajax'] = $url;
+
+        return $this;
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#display
+     */
+    public function display(string $display): static
+    {
+        $this->attributes['display'] = $display;
+
+        return $this;
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#escapeLabelHtml
+     */
+    public function escapeLabelHtml(bool $escape): static
+    {
+        $this->attributes['escapeLabelHtml'] = $escape;
+
+        return $this;
+    }
+
+    /**
+     * @param  array {
+     *     addButton?: string
+     *     inputPlaceholder?: string
+     *     noResults?: string
+     *     title?: string
+     *     placeholder?: string
+     *  } $i18n
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function i18n(array $i18n): static
+    {
+        $this->attributes['i18n'] = array_merge($this->attributes['i18n'] ?? [], $i18n);
+
+        return $this;
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function addButton(string $text): static
+    {
+        return $this->i18n(['addButton' => $text]);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function inputPlaceholder(string $text): static
+    {
+        return $this->i18n(['inputPlaceholder' => $text]);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function noResults(string $text): static
+    {
+        return $this->i18n(['noResults' => $text]);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function title(string $text): static
+    {
+        return $this->i18n(['title' => $text]);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#i18n
+     */
+    public function placeholder(string $text): static
+    {
+        return $this->i18n(['placeholder' => $text]);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#limit
+     */
+    public function limit(int $limit): static
+    {
+        $this->attributes['limit'] = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#multiple
+     */
+    public function multiple(bool $multiple = true): static
+    {
+        $this->attributes['multiple'] = $multiple;
+
+        return $this;
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#options
+     */
+    public function options(array|Arrayable $options): static
+    {
+        return parent::options($options);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#separator
+     */
+    public function separator(string $separator = ','): static
+    {
+        return parent::separator($separator);
+    }
+
+    /**
+     * @see https://editor.datatables.net/reference/field/tags#unique
+     */
+    public function unique(bool $unique = true): static
+    {
+        $this->attributes['unique'] = $unique;
+
+        return $this;
+    }
+}

--- a/src/Html/Editor/Fields/Tags.php
+++ b/src/Html/Editor/Fields/Tags.php
@@ -46,7 +46,9 @@ class Tags extends Field
      */
     public function i18n(array $i18n): static
     {
-        $options = (array) $this->attributes['i18n'];
+        $options = isset($this->attributes['i18n'])
+            ? (array) $this->attributes['i18n']
+            : [];
 
         $this->attributes['i18n'] = array_merge($options, $i18n);
 

--- a/src/Html/Editor/Fields/Tags.php
+++ b/src/Html/Editor/Fields/Tags.php
@@ -49,6 +49,7 @@ class Tags extends Field
      *     title?: string
      *     placeholder?: string
      *  } $i18n
+     *
      * @see https://editor.datatables.net/reference/field/tags#i18n
      */
     public function i18n(array $i18n): static

--- a/src/Html/Editor/Fields/Tags.php
+++ b/src/Html/Editor/Fields/Tags.php
@@ -42,19 +42,13 @@ class Tags extends Field
     }
 
     /**
-     * @param  array {
-     *     addButton?: string
-     *     inputPlaceholder?: string
-     *     noResults?: string
-     *     title?: string
-     *     placeholder?: string
-     *  } $i18n
-     *
      * @see https://editor.datatables.net/reference/field/tags#i18n
      */
     public function i18n(array $i18n): static
     {
-        $this->attributes['i18n'] = array_merge($this->attributes['i18n'] ?? [], $i18n);
+        $options = (array) $this->attributes['i18n'];
+
+        $this->attributes['i18n'] = array_merge($options, $i18n);
 
         return $this;
     }

--- a/tests/Html/Builder/BuilderOptionsLanguageTest.php
+++ b/tests/Html/Builder/BuilderOptionsLanguageTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class BuilderOptionsLanguageTest extends TestCase
 {

--- a/tests/Html/Builder/BuilderOptionsPluginsTest.php
+++ b/tests/Html/Builder/BuilderOptionsPluginsTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Builder;
 use Yajra\DataTables\Html\Button;
 use Yajra\DataTables\Html\SearchPane;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class BuilderOptionsPluginsTest extends TestCase
 {

--- a/tests/Html/Builder/BuilderOptionsTest.php
+++ b/tests/Html/Builder/BuilderOptionsTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Builder;
 use Yajra\DataTables\Html\Column;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class BuilderOptionsTest extends TestCase
 {

--- a/tests/Html/Builder/BuilderTest.php
+++ b/tests/Html/Builder/BuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use Illuminate\Support\HtmlString;
 use PHPUnit\Framework\Attributes\Test;
@@ -9,6 +9,7 @@ use Yajra\DataTables\Html\Column;
 use Yajra\DataTables\Html\ColumnDefinition;
 use Yajra\DataTables\Html\ColumnDefinitions;
 use Yajra\DataTables\Html\Editor\Editor;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class BuilderTest extends TestCase
 {

--- a/tests/Html/Builder/LayoutTest.php
+++ b/tests/Html/Builder/LayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use InvalidArgumentException;
 use Livewire\Exceptions\ComponentNotFoundException;
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Builder;
 use Yajra\DataTables\Html\Enums\LayoutPosition;
 use Yajra\DataTables\Html\Layout;
+use Yajra\DataTables\Html\Tests\TestCase;
 use Yajra\DataTables\Html\Tests\TestComponents\TestInlineView;
 use Yajra\DataTables\Html\Tests\TestComponents\TestLivewire;
 use Yajra\DataTables\Html\Tests\TestComponents\TestView;

--- a/tests/Html/Builder/SearchPaneTest.php
+++ b/tests/Html/Builder/SearchPaneTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Builder;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\SearchPane;
 use Yajra\DataTables\Html\Tests\Models\User;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class SearchPaneTest extends TestCase
 {

--- a/tests/Html/Column/ColumnDefinitionTest.php
+++ b/tests/Html/Column/ColumnDefinitionTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Column;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\ColumnDefinition;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class ColumnDefinitionTest extends TestCase
 {

--- a/tests/Html/Column/ColumnTest.php
+++ b/tests/Html/Column/ColumnTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Column;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Column;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class ColumnTest extends TestCase
 {

--- a/tests/Html/Editor/EditorFormOptionsTest.php
+++ b/tests/Html/Editor/EditorFormOptionsTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Editor;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Editor\FormOptions;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class EditorFormOptionsTest extends TestCase
 {

--- a/tests/Html/Editor/EditorTest.php
+++ b/tests/Html/Editor/EditorTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Editor;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Editor\Editor;
 use Yajra\DataTables\Html\Editor\Fields\Text;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class EditorTest extends TestCase
 {

--- a/tests/Html/Editor/Fields/FieldOptionsTest.php
+++ b/tests/Html/Editor/Fields/FieldOptionsTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Editor\Fields;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Editor\Fields\Options;
 use Yajra\DataTables\Html\Tests\Models\User;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class FieldOptionsTest extends TestCase
 {

--- a/tests/Html/Editor/Fields/FieldTest.php
+++ b/tests/Html/Editor/Fields/FieldTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests;
+namespace Yajra\DataTables\Html\Tests\Html\Editor\Fields;
 
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\Html\Editor\Fields;
 use Yajra\DataTables\Html\Tests\Models\User;
+use Yajra\DataTables\Html\Tests\TestCase;
 
 class FieldTest extends TestCase
 {

--- a/tests/Html/Editor/Fields/TagsTest.php
+++ b/tests/Html/Editor/Fields/TagsTest.php
@@ -36,6 +36,14 @@ class TagsTest extends TestCase
     }
 
     #[Test]
+    public function it_can_set_tags_i18n_props_directly(): void
+    {
+        $field = new Tags;
+        $field->addButton('Add Tag');
+        $this->assertSame('Add Tag', $field->toArray()['i18n']['addButton']);
+    }
+
+    #[Test]
     public function it_can_set_tags_i18n(): void
     {
         $field = new Tags;

--- a/tests/Html/Editor/Fields/TagsTest.php
+++ b/tests/Html/Editor/Fields/TagsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Yajra\DataTables\Html\Tests\Html\Editor\Fields;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Yajra\DataTables\Html\Editor\Fields\Tags;
+
+class TagsTest extends TestCase
+{
+    #[Test]
+    public function it_can_set_tags_ajax(): void
+    {
+        $field = new Tags;
+        $field->ajax('/tags');
+
+        $this->assertSame('/tags', $field->toArray()['ajax']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_display(): void
+    {
+        $field = new Tags;
+        $field->display('display');
+
+        $this->assertSame('display', $field->toArray()['display']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_escape_label_html(): void
+    {
+        $field = new Tags;
+        $field->escapeLabelHtml(true);
+
+        $this->assertTrue($field->toArray()['escapeLabelHtml']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_i18n(): void
+    {
+        $field = new Tags;
+        $field->i18n([
+            'addButton' => 'Add',
+            'inputPlaceholder' => 'Input',
+            'noResults' => 'No Results',
+            'title' => 'Title',
+            'placeholder' => 'Placeholder',
+        ]);
+
+        $this->assertSame('Add', $field->toArray()['i18n']['addButton']);
+        $this->assertSame('Input', $field->toArray()['i18n']['inputPlaceholder']);
+        $this->assertSame('No Results', $field->toArray()['i18n']['noResults']);
+        $this->assertSame('Title', $field->toArray()['i18n']['title']);
+        $this->assertSame('Placeholder', $field->toArray()['i18n']['placeholder']);
+
+        $field->addButton('Add Button')
+            ->inputPlaceholder('Input Placeholder')
+            ->noResults('No Results X')
+            ->title('Title X')
+            ->placeholder('Placeholder X');
+
+        $this->assertSame('Add Button', $field->toArray()['i18n']['addButton']);
+        $this->assertSame('Input Placeholder', $field->toArray()['i18n']['inputPlaceholder']);
+        $this->assertSame('No Results X', $field->toArray()['i18n']['noResults']);
+        $this->assertSame('Title X', $field->toArray()['i18n']['title']);
+        $this->assertSame('Placeholder X', $field->toArray()['i18n']['placeholder']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_type(): void
+    {
+        $field = new Tags;
+
+        $this->assertSame('tags', $field->toArray()['type']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_limit(): void
+    {
+        $field = new Tags;
+        $field->limit(2);
+
+        $this->assertSame(2, $field->toArray()['limit']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_multiple(): void
+    {
+        $field = new Tags;
+        $field->multiple();
+
+        $this->assertTrue($field->toArray()['multiple']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_options(): void
+    {
+        $field = new Tags;
+        $field->options(['tag1', 'tag2']);
+
+        $this->assertSame(['tag1', 'tag2'], $field->toArray()['options']);
+
+        $field->options([
+            ['value' => 'tag1', 'label' => 'Tag 1'],
+            ['value' => 'tag2', 'label' => 'Tag 2'],
+        ]);
+
+        $this->assertSame([
+            ['value' => 'tag1', 'label' => 'Tag 1'],
+            ['value' => 'tag2', 'label' => 'Tag 2'],
+        ], $field->toArray()['options']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_separator(): void
+    {
+        $field = new Tags;
+        $field->separator(',');
+
+        $this->assertSame(',', $field->toArray()['separator']);
+    }
+
+    #[Test]
+    public function it_can_set_tags_unique(): void
+    {
+        $field = new Tags;
+        $field->unique();
+
+        $this->assertTrue($field->toArray()['unique']);
+    }
+}

--- a/tests/Html/Extensions/SearchPaneTest.php
+++ b/tests/Html/Extensions/SearchPaneTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yajra\DataTables\Html\Tests\Html\Builder;
+namespace Yajra\DataTables\Html\Tests\Html\Extensions;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
Add support for Editor 2.4.0 [tags field](https://editor.datatables.net/reference/field/tags)

### Client-side

```php
use Yajra\DataTables\Html\Editor\Fields\Tags;

Tags::make('permissions[].id')
    ->name('permissions')
    ->addButton('Add Permission')
    ->title('Permission Tags')
    ->noResults('No permissions found.')
    ->placeholder('Type to search permissions')
    ->inputPlaceholder('Search permissions')
    ->limit(2)
    ->label('Permissions')
    ->tableOptions('permissions', 'name'),
```

### Server-side via AJAX with Editor action

#### Field

```php
use Yajra\DataTables\Html\Editor\Fields\Tags;

Tags::make('permissions[].id')
    ->name('permissions')
    ->addButton('Add Permission')
    ->title('Permission Tags')
    ->noResults('No permissions found.')
    ->placeholder('Type to search permissions')
    ->inputPlaceholder('Search permissions')
    ->limit(2)
    ->label('Permissions')
    ->ajax(),
```

#### Editor

```php
    protected array $customActions = ['search'];

    public function search(Request $request): JsonResponse
    {
        $search = $request->get('search');

        $permissions = Permission::query()
            ->whereLike('name', "%{$search}%")
            ->paginate()
            ->map(function (User $permission) {
                return [
                    'value' => $permission->id,
                    'label' => $permission->name,
                ];
            });

        return $this->toJson($permissions->toArray());
    }
```