### PR TITLE
fix: add missing exportRender property

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -28,6 +28,7 @@ use Yajra\DataTables\Html\Options\Plugins\SearchPanes;
  * @property string $contentPadding
  * @property string $createdCell
  * @property string $exportFormat
+ * @property callable $exportRender
  *
  * @see https://datatables.net/reference/option/#columns
  */


### PR DESCRIPTION
See: https://github.com/yajra/laravel-datatables-export/pull/71
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-html/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
