### PR TITLE
fix: ensure DataTables initialization after the page fully loads

### DIFF
--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,4 +1,6 @@
+window.addEventListener("load", function() {
 $(function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});
+});
 @foreach ($scripts as $script)
 @include($script)
 @endforeach

--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,6 +1,4 @@
-window.addEventListener("load", function() {
-$(function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});
-});
+window.addEventListener("load", function() {$(function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});});
 @foreach ($scripts as $script)
 @include($script)
 @endforeach

--- a/tests/Html/Builder/BuilderTest.php
+++ b/tests/Html/Builder/BuilderTest.php
@@ -98,10 +98,10 @@ class BuilderTest extends TestCase
         $this->assertEquals($expected, $table);
 
         $script = $builder->scripts()->toHtml();
-        $expected = '<script type="text/javascript">$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});</script>';
+        $expected = '<script type="text/javascript">window.addEventListener("load", function() {$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});});</script>';
         $this->assertEquals($expected, $script);
 
-        $expected = '$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});';
+        $expected = 'window.addEventListener("load", function() {$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});});';
         $this->assertEquals($expected, $builder->generateScripts()->toHtml());
     }
 


### PR DESCRIPTION
Ensure DataTables initialization after the page fully loads by adding load event listener.