### PR TITLE
fix: use DOMContentLoaded

### DIFF
--- a/src/resources/views/editor.blade.php
+++ b/src/resources/views/editor.blade.php
@@ -1,4 +1,4 @@
-$(function(){
+document.addEventListener("DOMContentLoaded", function(){
     window.{{ config('datatables-html.namespace', 'LaravelDataTables') }} = window.{{ config('datatables-html.namespace', 'LaravelDataTables') }} || {};
     $.ajaxSetup({headers: {'X-CSRF-TOKEN': '{{csrf_token()}}'}});
     @foreach($editors as $editor)

--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,4 +1,4 @@
-$(function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});
+document.addEventListener("DOMContentLoaded",function(){window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}=window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}||{};window.{{ config('datatables-html.namespace', 'LaravelDataTables') }}["%1$s"]=$("#%1$s").DataTable(%2$s);});
 @foreach ($scripts as $script)
 @include($script)
 @endforeach

--- a/tests/Html/Builder/BuilderTest.php
+++ b/tests/Html/Builder/BuilderTest.php
@@ -98,10 +98,10 @@ class BuilderTest extends TestCase
         $this->assertEquals($expected, $table);
 
         $script = $builder->scripts()->toHtml();
-        $expected = '<script type="text/javascript">$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});</script>';
+        $expected = '<script type="text/javascript">document.addEventListener("DOMContentLoaded",function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});</script>';
         $this->assertEquals($expected, $script);
 
-        $expected = '$(function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});';
+        $expected = 'document.addEventListener("DOMContentLoaded",function(){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo-table"]=$("#foo-table").DataTable({"serverSide":true,"processing":true,"ajax":"","columns":[{"data":"foo","name":"foo","title":"Foo","orderable":true,"searchable":true},{"data":"baz","name":"baz","title":"Baz","orderable":true,"searchable":true}]});});';
         $this->assertEquals($expected, $builder->generateScripts()->toHtml());
     }
 


### PR DESCRIPTION
In our project, we sometimes faces the following  javascript error:
> Uncaught Cannot extend unknown button type: reset

This is because buttons are defined inside the `DOMContentLoaded` event:
https://github.com/yajra/laravel-datatables-vite/blob/3d1d1364e43f9bea547dae9a19236bcfd38d32bd/js/buttons/reset.js#L9

That error does not happens every time, I cannot explain why, but I am not able to reproduce it if I use `DOMContentLoaded` instead of `$(function(){ }`.
For some reason, even if it is supposed to be equivalent to `DOMContentLoaded`, `$(function(){ }` seems to be faster than `DOMContentLoaded` in some cases.

So let's use `DOMContentLoaded` here to be consistent with buttons.