### PR TITLE
Fix namespace of laravellux/html HtmlServiceProvider

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Yajra\DataTables;
 
-use LaravelLux\Html\HtmlServiceProvider as CollectiveHtml;
+use Collective\Html\HtmlServiceProvider as CollectiveHtml;
 use Illuminate\Support\ServiceProvider;
 
 class HtmlServiceProvider extends ServiceProvider


### PR DESCRIPTION
Fixed the namespace of laravellux/html HtmlServiceProvider in the import statement.

Though this is a different package, there are no changes in the namespace. 

Fixes #241 