### PR TITLE
feat: Allow passing data to javascript template

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -272,7 +272,7 @@ class Builder
         return $this;
     }
 
-    public function templateData(array|\Closure $data = []): static
+    public function setTemplateData(array|\Closure $data = []): static
     {
         if ($data instanceof \Closure) {
             $data = $data($this) ?? [];

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -276,7 +276,7 @@ class Builder
     {
         return $this->template;
     }
-  
+
     public function setTemplateData(array|\Closure $data = []): static
     {
         if ($data instanceof \Closure) {

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -62,6 +62,8 @@ class Builder
 
     protected array $additionalScripts = [];
 
+    protected array $templateData = [];
+
     public function __construct(public Repository $config, public Factory $view, public HtmlBuilder $html)
     {
         /** @var array $defaults */
@@ -158,7 +160,13 @@ class Builder
 
         $template = $this->template ?: $configTemplate;
 
-        return $this->view->make($template, ['editors' => $this->editors, 'scripts' => $this->additionalScripts])->render();
+        return $this->view->make(
+            $template,
+            array_merge(
+                ['editors' => $this->editors, 'scripts' => $this->additionalScripts],
+                $this->templateData,
+            )
+        )->render();
     }
 
     /**
@@ -260,6 +268,17 @@ class Builder
     public function addScript(string $view): static
     {
         $this->additionalScripts[] = $view;
+
+        return $this;
+    }
+
+    public function templateData(array|\Closure $data = []): static
+    {
+        if ($data instanceof \Closure) {
+            $data = $data($this) ?? [];
+        }
+
+        $this->templateData = $data;
 
         return $this;
     }

--- a/tests/Html/Builder/BuilderTest.php
+++ b/tests/Html/Builder/BuilderTest.php
@@ -318,7 +318,6 @@ class BuilderTest extends TestCase
 
         $builder
             ->setTableId('my-table')
-            ->addScript('test-builder-script')
             ->setTemplateData(function (Builder $builder): array {
                 return [
                     'tableId' => $builder->getTableId(),

--- a/tests/Html/Builder/BuilderTest.php
+++ b/tests/Html/Builder/BuilderTest.php
@@ -303,4 +303,32 @@ class BuilderTest extends TestCase
 
         $this->assertCount(1, $builder->getColumns());
     }
+
+    #[Test]
+    public function it_can_set_template_data(): void
+    {
+        $builder = $this->getHtmlBuilder()
+            ->addScript('test-builder-script')
+            ->setTemplateData(['message' => 'Test Message']);
+
+        $this->assertStringContainsString(
+            "console.log({ tableId: 'noneset', message: 'Test Message' });",
+            $builder->generateScripts()->toHtml()
+        );
+
+        $builder
+            ->setTableId('my-table')
+            ->addScript('test-builder-script')
+            ->setTemplateData(function (Builder $builder): array {
+                return [
+                    'tableId' => $builder->getTableId(),
+                    'message' => 'Set Template Data Using Callback',
+                ];
+            });
+
+        $this->assertStringContainsString(
+            "console.log({ tableId: 'my-table', message: 'Set Template Data Using Callback' });",
+            $builder->generateScripts()->toHtml()
+        );
+    }
 }

--- a/tests/TestComponents/test-builder-script.blade.php
+++ b/tests/TestComponents/test-builder-script.blade.php
@@ -1,0 +1,1 @@
+console.log({ tableId: @js($tableId ?? 'noneset'), message: @js($message) });


### PR DESCRIPTION
This pull request allows devs to add extra template data to javascript template.

Currently, we can add extra js using addScript() method:
```php
class MyDataTableHtml extends DataTableHtml
{
    public function handle(): Builder
    {
        return $this->getHtmlBuilder();
            ->addScript('inline-edit-script');
    }
}
```

However, it is not possible to pass data to the template. Since the template is just a blade file, I think we should be able to do something like this:
```php
{{-- inline-edit-script.blade.php -- }}

table.on('click', 'tbody td:not(:first-child)', function (e) {
   {{ $editorInstance }}.inline(this);
});
```

By allowing so, the example script could be reused on datatables that needs inline editing having $editorInstance dynamically.

With this PR, $editorInstance can be set dynamically.
```php
class MyDataTableHtml extends DataTableHtml
{
    public function handle(): Builder
    {
        return $this->getHtmlBuilder();
            ->addScript('inline-edit-script')
            ->setTemplateData([
                'editorInstance' => 'inlineEditor',
            ])

            // or

            ->setTemplateData(function (Builder $builder): array {
                if ($condition) {
                    return ['editorInstance' => 'specialInlineEditor'];
                }

                return ['editorInstance' => 'inlineEditor'];
            });
    }
}
```