### PR TITLE
Add ->style() method to Column class for inline CSS styling in DataTables

### DIFF
--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -89,6 +89,18 @@ class Column extends Fluent
     }
 
     /**
+     * Set column style.
+     *
+     * @return $this
+     */
+    public function style(string $css): static
+    {
+        $this->attributes['style'] = $css;
+
+        return $this;
+    }
+
+    /**
      * Create a computed column that is not searchable/orderable.
      */
     public static function computed(string $data, ?string $title = null): Column


### PR DESCRIPTION
## Feature: Add `->style()` Method to Column Class

### Summary
This PR introduces a new `->style()` method to the `Column` class in Yajra DataTables. Html  
It allows developers to apply **inline CSS styles** directly to individual columns when defining DataTables columns.  

### Usage
```php
/**
* Get the dataTable columns definition.
*
* @return \Yajra\DataTables\Html\Column[]
* 
* */
public function getColumns(): array
{
    return [
        Column::make('title')->style('color: red; font-weight: 700;'), // Inline CSS added here
    ];
}
