### PR TITLE
Support Livewire v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "orchestra/testbench": "^10",
         "laravel/pint": "^1.21",
         "rector/rector": "^2.0",
-        "livewire/livewire": "^3.4"
+        "livewire/livewire": "^3.4|^4.0.2"
     },
     "suggest": {
         "laravel/livewire": "Required for Livewire layout support."


### PR DESCRIPTION
Updated the Livewire dependency constraint in `composer.json` to support both Livewire v3.4+ and Livewire v4.0.2+. Changed the constraint from `^3.4` to `^3.4|^4.0.2`, allowing the package to work with both major versions while maintaining backward compatibility with Livewire v3.

This change ensures that users can upgrade to Livewire v4 without breaking compatibility with this package, and existing users on Livewire v3 can continue using the package without issues.